### PR TITLE
feat(pulse): add supporting pulsesource

### DIFF
--- a/SablePulse/Source/PulseSource.swift
+++ b/SablePulse/Source/PulseSource.swift
@@ -1,0 +1,55 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SableFoundation
+
+/// An internal structure that represents the origin of a pulse message.
+///
+/// `PulseSource` is used within the SablePulse system to track message provenance
+/// and causation chains. It appears in `PulseMeta` through the `source` and `echoes`
+/// properties, providing information about where pulses originated and what preceded them.
+///
+/// This type is not meant to be created directly by end users, but rather is managed
+/// internally by the SablePulse system. The `Pulsable` and `Representable` conformances
+/// ensure it can safely traverse actor boundaries and provide consistent identity information.
+public struct PulseSource: Pulsable, Representable {
+  /// A unique identifier for the pulse source.
+  public let id: UUID
+  
+  /// A human-readable name for the pulse source.
+  public let name: String
+  
+  /// Creates a `PulseSource` from any type that conforms to `Representable`.
+  ///
+  /// Used internally by the SablePulse system to track the origins of pulse messages.
+  ///
+  /// - Parameter source: A `Representable` object to create a source from
+  /// - Returns: A new `PulseSource` with the same identity and name as the source
+  internal static func From(source: any Representable) -> PulseSource {
+    return PulseSource(id: source.id, name: source.name)
+  }
+  
+  /// Creates a `PulseSource` from a pulse message.
+  ///
+  /// Used internally by the SablePulse system to track causation chains,
+  /// where one pulse causes another to be emitted.
+  ///
+  /// - Parameter pulse: A `Pulse` message to create a source from
+  /// - Returns: A new `PulseSource` with the same identity and name as the pulse
+  // internal static func From<Data: Pulsable>(pulse: Pulse<Data>) -> PulseSource {
+  //   return PulseSource(id: pulse.id, name: pulse.name)
+  // }
+  
+  /// Private initializer to ensure `PulseSource` instances are only created
+  /// through the internal factory methods.
+  ///
+  /// - Parameters:
+  ///   - id: A unique identifier for the source
+  ///   - name: A human-readable name for the source
+  private init(id: UUID, name: String) {
+    self.id = id
+    self.name = name
+  }
+}

--- a/SablePulse/Tests/PulseSource.swift
+++ b/SablePulse/Tests/PulseSource.swift
@@ -1,0 +1,102 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import SableFoundation
+
+@testable import SablePulse
+
+@Suite("SablePulse/PulseSource")
+struct PulseSourceTests {
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("PulseSource conforms to Pulsable")
+  func pulse_source_conforms_to_pulsable() throws {
+    // Given
+    let is_pulsable = (PulseSource.self as Any) is any Pulsable.Type
+    
+    // Then
+    #expect(is_pulsable)
+  }
+  
+  @Test("PulseSource conforms to Representable")
+  func pulse_source_conforms_to_representable() throws {
+    // Given
+    let is_representable = (PulseSource.self as Any) is any Representable.Type
+    
+    // Then
+    #expect(is_representable)
+  }
+  
+  // MARK: - Internal Factory Method Tests
+  
+  // Test struct that conforms to Representable
+  struct TestRepresentable: Representable {
+    let id = UUID()
+    let name = "Test Representable"
+  }
+  
+  @Test("From(source:) creates PulseSource from Representable")
+  func from_source_creates_pulse_source_from_representable() throws {
+    // Given
+    let representable = TestRepresentable()
+    
+    // When
+    let source = PulseSource.From(source: representable)
+    
+    // Then
+    #expect(source.id == representable.id)
+    #expect(source.name == representable.name)
+  }
+  
+  /*
+   * Test for From(pulse:) is omitted until Pulse is available in the repository.
+   * Add the following test once Pulse is available:
+   *
+   * @Test("From(pulse:) creates PulseSource from Pulse")
+   * func from_pulse_creates_pulse_source_from_pulse() throws {
+   *   // Given
+   *   let data = TestPulseData(value: "Test Data")
+   *   let pulse = Pulse(data: data)
+   *
+   *   // When
+   *   let source = PulseSource.From(pulse: pulse)
+   *
+   *   // Then
+   *   #expect(source.id == pulse.id)
+   *   #expect(source.name == pulse.name)
+   * }
+   */
+  
+  // MARK: - Behavior Tests
+  
+  @Test("PulseSource description combines name and id")
+  func pulse_source_description_combines_name_and_id() throws {
+    // Given
+    let representable = TestRepresentable()
+    let source = PulseSource.From(source: representable)
+    
+    // When
+    let description = source.description
+    
+    // Then
+    #expect(description == "\(source.name):\(source.id)")
+  }
+  
+  @Test("Different PulseSource instances have different ids")
+  func different_pulse_source_instances_have_different_ids() throws {
+    // Given
+    let representable1 = TestRepresentable()
+    let representable2 = TestRepresentable()
+    
+    // When
+    let source1 = PulseSource.From(source: representable1)
+    let source2 = PulseSource.From(source: representable2)
+    
+    // Then
+    #expect(source1.id != source2.id)
+  }
+}


### PR DESCRIPTION
This is a datatype used in pulse metadata to help with debugging and such like that. Generally users will only ever interact with the data itself as the creation/management of it is handled in other places. <3