### PR TITLE
feat(pulse) added supporting type pulsemeta

### DIFF
--- a/SablePulse/Source/PulseMeta.swift
+++ b/SablePulse/Source/PulseMeta.swift
@@ -1,0 +1,123 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SableFoundation
+
+/// Metadata that provides operational context for a pulse message.
+///
+/// `PulseMeta` encapsulates system-level metadata about a pulse, including:
+/// - Debug status for development and testing
+/// - Tracing for message flow visualization
+/// - Source tracking for message origin
+/// - Echo tracking for causal relationships
+/// - Priority for task scheduling
+/// - Tags for filtering and categorization
+///
+/// This structure is primarily managed by the internal fluent builders on `Pulse`
+/// and is not typically created directly by end users.
+///
+/// The metadata travels with each pulse through the system, enabling:
+/// - Operational tracing for debugging complex message flows
+/// - Priority-based scheduling in async contexts
+/// - Causal chain tracking to understand message relationships
+/// - Filtering and routing based on tags
+///
+/// `PulseMeta` conforms to `Pulsable` to ensure it can safely traverse actor
+/// boundaries while maintaining type safety.
+public struct PulseMeta: Pulsable {
+  /// Indicates whether this pulse was created in debug mode.
+  ///
+  /// When true, the pulse may receive special handling:
+  /// - Additional logging and tracing
+  /// - Inclusion in debug visualizations
+  /// - Heightened verbosity in error contexts
+  ///
+  /// Debug pulses are particularly useful during development to track
+  /// specific message flows through complex systems.
+  public let debug: Bool
+  
+  /// A unique identifier for tracing this pulse through the system.
+  ///
+  /// The trace ID remains consistent across pulse transformations and can be used
+  /// to visualize a complete message flow. Multiple pulses may share the same
+  /// trace ID if they are part of the same logical operation or user interaction.
+  ///
+  /// This enables building comprehensive visualizations of message propagation
+  /// throughout a distributed system.
+  public let trace: UUID
+  
+  /// The system or component that generated this pulse.
+  ///
+  /// Captures the origin of a pulse, providing context about where the message
+  /// was created. This is essential for debugging and for understanding
+  /// message flow directionality.
+  ///
+  /// The source is typically generated automatically from the emitting actor
+  /// or component's identity information.
+  public let source: Optional<PulseSource>
+  
+  /// The pulse that caused or preceded this one.
+  ///
+  /// Establishes causal relationships between pulses, enabling the construction
+  /// of causal chains to understand how one message led to another.
+  ///
+  /// When a component processes a pulse and emits a new one in response,
+  /// the original pulse's identity is captured here to maintain the
+  /// relationship between cause and effect.
+  public let echoes: Optional<PulseSource>
+  
+  /// The scheduling priority of this pulse.
+  ///
+  /// Determines how urgently this pulse should be processed within
+  /// task scheduling systems. Higher priority pulses are processed
+  /// before lower priority ones when resources are constrained.
+  ///
+  /// Stored as a raw value to enable serialization, but accessors on
+  /// `Pulse` provide strongly-typed access via `TaskPriority`.
+  public let priority: TaskPriority.RawValue
+  
+  /// A set of string tags that provide a simple extension mechanism.
+  ///
+  /// Tags enable users to extend pulse functionality without modifying the
+  /// core structure. They serve multiple purposes:
+  /// - Feature flagging to enable or disable specific behaviors
+  /// - Custom routing based on application-specific concerns
+  /// - Contextual metadata that specific receivers might understand
+  /// - Application-level categorization beyond the core framework
+  ///
+  /// Since PulseMeta itself isn't directly extendable (at least until potential
+  /// future language features like union types), tags provide a lightweight way
+  /// for users to add their own metadata and build custom behaviors on top of
+  /// the messaging system.
+  public let tags: Set<String>
+  
+  /// Creates a new instance of pulse metadata with specified attributes.
+  ///
+  /// This initializer is internal as end users should not create `PulseMeta`
+  /// directly. Instead, they should use the fluent builders on `Pulse`.
+  ///
+  /// - Parameters:
+  ///   - debug: Whether this pulse is in debug mode
+  ///   - trace: A unique identifier for tracing this pulse
+  ///   - source: The component that generated this pulse
+  ///   - echoes: The pulse that caused or preceded this one
+  ///   - priority: The processing priority for this pulse
+  ///   - tags: A set of string tags for filtering and categorization
+  internal init(
+    debug: Bool = false,
+    trace: UUID = UUID(),
+    source: Optional<PulseSource> = .none,
+    echoes: Optional<PulseSource> = .none,
+    priority: TaskPriority = .medium,
+    tags: Set<String> = []
+  ) {
+    self.debug = debug
+    self.trace = trace
+    self.source = source
+    self.echoes = echoes
+    self.priority = priority.rawValue
+    self.tags = tags
+  }
+}

--- a/SablePulse/Tests/PulseMeta.swift
+++ b/SablePulse/Tests/PulseMeta.swift
@@ -1,0 +1,192 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import SableFoundation
+
+@testable import SablePulse
+
+@Suite("SablePulse/PulseMeta")
+struct PulseMetaTests {
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("PulseMeta conforms to Pulsable")
+  func pulse_meta_conforms_to_pulsable() throws {
+    // Given
+    let is_pulsable = (PulseMeta.self as Any) is any Pulsable.Type
+    
+    // Then
+    #expect(is_pulsable)
+  }
+  
+  // MARK: - Default Values Tests
+  
+  @Test("PulseMeta initializes with correct default values")
+  func pulse_meta_initializes_with_default_values() throws {
+    // When
+    let meta = PulseMeta()
+    
+    // Then
+    #expect(!meta.debug, "Debug should default to false")
+    #expect(meta.source == nil, "Source should default to nil")
+    #expect(meta.echoes == nil, "Echoes should default to nil")
+    #expect(meta.priority == TaskPriority.medium.rawValue, "Priority should default to medium")
+    #expect(meta.tags.isEmpty, "Tags should default to empty set")
+  }
+  
+  // MARK: - Custom Values Tests
+  
+  @Test("PulseMeta initializes with custom debug value")
+  func pulse_meta_initializes_with_custom_debug_value() throws {
+    // When
+    let meta = PulseMeta(debug: true)
+    
+    // Then
+    #expect(meta.debug, "Debug should be set to true")
+  }
+  
+  @Test("PulseMeta initializes with custom trace value")
+  func pulse_meta_initializes_with_custom_trace_value() throws {
+    // Given
+    let custom_trace = UUID()
+    
+    // When
+    let meta = PulseMeta(trace: custom_trace)
+    
+    // Then
+    #expect(meta.trace == custom_trace, "Trace should match provided UUID")
+  }
+  
+  @Test("PulseMeta initializes with custom source value")
+  func pulse_meta_initializes_with_custom_source_value() throws {
+    // Given
+    struct TestRepresentable: Representable {
+      let id = UUID()
+      let name = "Test Source"
+    }
+    let source_representable = TestRepresentable()
+    let source = PulseSource.From(source: source_representable)
+    
+    // When
+    let meta = PulseMeta(source: source)
+    
+    // Then
+    #expect(meta.source != nil, "Source should not be nil")
+    #expect(meta.source?.id == source.id, "Source id should match provided source")
+    #expect(meta.source?.name == source.name, "Source name should match provided source")
+  }
+  
+  @Test("PulseMeta initializes with custom echoes value")
+  func pulse_meta_initializes_with_custom_echoes_value() throws {
+    // Given
+    struct TestRepresentable: Representable {
+      let id = UUID()
+      let name = "Test Echo"
+    }
+    let echo_representable = TestRepresentable()
+    let echo = PulseSource.From(source: echo_representable)
+    
+    // When
+    let meta = PulseMeta(echoes: echo)
+    
+    // Then
+    #expect(meta.echoes != nil, "Echoes should not be nil")
+    #expect(meta.echoes?.id == echo.id, "Echoes id should match provided echo source")
+    #expect(meta.echoes?.name == echo.name, "Echoes name should match provided echo source")
+  }
+  
+  @Test("PulseMeta initializes with custom priority value")
+  func pulse_meta_initializes_with_custom_priority_value() throws {
+    // When
+    let meta = PulseMeta(priority: .high)
+    
+    // Then
+    #expect(meta.priority == TaskPriority.high.rawValue, "Priority should be set to high")
+  }
+  
+  @Test("PulseMeta initializes with custom tags value")
+  func pulse_meta_initializes_with_custom_tags_value() throws {
+    // Given
+    let custom_tags: Set<String> = ["feature_flag", "beta", "testing"]
+    
+    // When
+    let meta = PulseMeta(tags: custom_tags)
+    
+    // Then
+    #expect(meta.tags == custom_tags, "Tags should match provided set")
+    #expect(meta.tags.count == 3, "Tags should contain exactly 3 items")
+  }
+  
+  // MARK: - Serialization Tests
+  
+  @Test("PulseMeta can be encoded and decoded")
+  func pulse_meta_can_be_encoded_and_decoded() throws {
+    // Given
+    struct TestRepresentable: Representable {
+      let id = UUID()
+      let name = "Test Source"
+    }
+    let source = PulseSource.From(source: TestRepresentable())
+    let original = PulseMeta(
+      debug: true,
+      trace: UUID(),
+      source: source,
+      priority: .high,
+      tags: ["test", "serialization"]
+    )
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    // When
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(PulseMeta.self, from: data)
+    
+    // Then
+    #expect(decoded.debug == original.debug)
+    #expect(decoded.trace == original.trace)
+    #expect(decoded.source?.id == original.source?.id)
+    #expect(decoded.source?.name == original.source?.name)
+    #expect(decoded.echoes == original.echoes)
+    #expect(decoded.priority == original.priority)
+    #expect(decoded.tags == original.tags)
+  }
+  
+  // MARK: - Equality Tests
+  
+  @Test("Equal PulseMeta instances compare as equal")
+  func equal_pulse_meta_instances_compare_as_equal() throws {
+    // Given
+    let trace_id = UUID()
+    let tags: Set<String> = ["tag1", "tag2"]
+    
+    // When
+    let meta1 = PulseMeta(
+      debug: true,
+      trace: trace_id,
+      priority: .low,
+      tags: tags
+    )
+    let meta2 = PulseMeta(
+      debug: true,
+      trace: trace_id,
+      priority: .low,
+      tags: tags
+    )
+    
+    // Then
+    #expect(meta1 == meta2)
+  }
+  
+  @Test("Different PulseMeta instances compare as not equal")
+  func different_pulse_meta_instances_compare_as_not_equal() throws {
+    // Given
+    let meta1 = PulseMeta(debug: true, priority: .high)
+    let meta2 = PulseMeta(debug: false, priority: .low)
+    
+    // Then
+    #expect(meta1 != meta2)
+  }
+}


### PR DESCRIPTION
PulseMeta ends up being used internally in the larger ecosystem quite a bit. It's worth noting here that there's an attempt at separation on what's in Pulse vs PulseMeta that is essentially, "the things that are the identity of a pulse" vs "the things that help systems track and use pulses". Also! Being borne out of a larger system PulseMeta didn't really need any kind of extendability. That gave the benefit of strong type safety. I would love to be able to open it up more to end use cases but every way I tried to do that in experimenting before this public release came with tradeoffs I was unhappy with. So for now, tags are about all it gets. I'd love to see union types hit Swift someday though.