### PR TITLE
feat(pulse): add internal fluently methods

### DIFF
--- a/SablePulse/Source/Extensions/Pulse/PulseFluently.swift
+++ b/SablePulse/Source/Extensions/Pulse/PulseFluently.swift
@@ -1,0 +1,76 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SableFoundation
+
+/// Internal extension providing fluent builder pattern support for Pulse instances.
+///
+/// This extension enables convenient modification of Pulse instances through a fluent interface,
+/// making it easier to create derived Pulses while preserving core identity information.
+/// The methods maintain immutability by creating new instances rather than modifying existing ones.
+internal extension Pulse {
+  /// Creates a new Pulse instance with selectively updated properties.
+  ///
+  /// This static factory method enables the fluent builder pattern by constructing
+  /// a new Pulse that preserves the identity (id and timestamp) of the original
+  /// while optionally updating the data payload and/or metadata.
+  ///
+  /// ```swift
+  /// // Create a new pulse with updated metadata but same data
+  /// let updated_pulse = Pulse.Fluently(original_pulse, meta: new_meta)
+  ///
+  /// // Create a new pulse with updated data but same metadata
+  /// let transformed_pulse = Pulse.Fluently(original_pulse, data: new_data)
+  ///
+  /// // Create a new pulse with both updated data and metadata
+  /// let complete_update = Pulse.Fluently(original_pulse, data: new_data, meta: new_meta)
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - pulse: The original Pulse instance whose identity will be preserved
+  ///   - data: Optional new data payload (defaults to nil, which retains original data)
+  ///   - meta: Optional new metadata (defaults to nil, which retains original metadata)
+  /// - Returns: A new Pulse instance with the same identity but potentially updated components
+  static func Fluently(
+    _ pulse: Pulse<Data>,
+    data: Optional<Data> = .none,
+    meta: Optional<PulseMeta> = .none
+  ) -> Pulse<Data> {
+    return Pulse(
+      id: pulse.id,
+      timestamp: pulse.timestamp,
+      data: data.otherwise(pulse.data),
+      meta: meta.otherwise(pulse.meta)
+    )
+  }
+  
+  /// Creates a new Pulse with selectively updated properties using the fluent pattern.
+  ///
+  /// This instance method provides a more natural interface for the fluent builder pattern,
+  /// allowing callsite code to create modified versions of a Pulse through method chaining.
+  /// It preserves the identity of the original Pulse while allowing updates to data and metadata.
+  ///
+  /// ```swift
+  /// // Create a simple update with new metadata
+  /// let debug_pulse = original_pulse.fluently(meta: debug_meta)
+  ///
+  /// // Chain multiple fluent operations
+  /// let final_pulse = original_pulse
+  ///   .debug(true)                // Uses fluently internally
+  ///   .priority(.high)            // Uses fluently internally
+  ///   .tagged("auth", "critical") // Uses fluently internally
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - data: Optional new data payload (defaults to nil, which retains original data)
+  ///   - meta: Optional new metadata (defaults to nil, which retains original metadata)
+  /// - Returns: A new Pulse instance with the same identity but potentially updated components
+  func fluently(
+    data: Optional<Data> = .none,
+    meta: Optional<PulseMeta> = .none
+  ) -> Pulse<Data> {
+    return Pulse.Fluently(self, data: data, meta: meta)
+  }
+}

--- a/SablePulse/Source/Extensions/PulseMeta/MetaFluently.swift
+++ b/SablePulse/Source/Extensions/PulseMeta/MetaFluently.swift
@@ -1,0 +1,91 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SableFoundation
+
+/// Extension to `PulseMeta` providing fluent modification capabilities.
+///
+/// These methods enable immutable transformation of `PulseMeta` instances
+/// through a natural language fluent interface. The design maintains
+/// immutability while allowing for property updates, which aligns with
+/// Sable's design principle of thread safety in actor-based environments.
+///
+/// Fluent builders are primarily used internally by the `Pulse` type to
+/// implement its own public fluent interface, though they may be used
+/// directly when creating custom metadata handling.
+///
+/// ```swift
+/// // Example of internal usage through Pulse's fluent interface
+/// let enhanced_pulse = original_pulse
+///   .debug(true)
+///   .priority(.high)
+///   .tagged("critical", "auth")
+/// ```
+internal extension PulseMeta {
+  /// Creates a new PulseMeta instance with updated properties.
+  ///
+  /// Used internally by the fluent builders on `Pulse` to maintain immutability
+  /// while allowing property updates.
+  ///
+  /// - Parameters:
+  ///   - original: The source PulseMeta instance to copy values from
+  ///   - debug: Whether this pulse is in debug mode
+  ///   - trace: A unique identifier for tracing this pulse
+  ///   - source: The component that generated this pulse
+  ///   - echoes: The pulse that caused or preceded this one
+  ///   - priority: The processing priority for this pulse
+  ///   - tags: A set of string tags for filtering and categorization
+  /// - Returns: A new PulseMeta instance with the specified properties updated
+  static func Fluently(
+    _ original: PulseMeta,
+    debug: Optional<Bool> = .none,
+    trace: Optional<UUID> = .none,
+    source: Optional<PulseSource> = .none,
+    echoes: Optional<PulseSource> = .none,
+    priority: Optional<TaskPriority> = .none,
+    tags: Optional<Set<String>> = .none
+  ) -> PulseMeta {
+    return PulseMeta(
+      debug: debug.otherwise(original.debug),
+      trace: trace.otherwise(original.trace),
+      source: source.optionally(original.source),
+      echoes: echoes.optionally(original.echoes),
+      priority: priority.otherwise(TaskPriority(rawValue: original.priority)),
+      tags: tags.otherwise(original.tags)
+    )
+  }
+  
+  /// Creates a new PulseMeta instance with updated properties.
+  ///
+  /// This instance method provides a more ergonomic way to use the fluent pattern,
+  /// automatically passing the current instance to the static Fluently method.
+  ///
+  /// - Parameters:
+  ///   - debug: Whether this pulse is in debug mode
+  ///   - trace: A unique identifier for tracing this pulse
+  ///   - source: The component that generated this pulse
+  ///   - echoes: The pulse that caused or preceded this one
+  ///   - priority: The processing priority for this pulse
+  ///   - tags: A set of string tags for filtering and categorization
+  /// - Returns: A new PulseMeta instance with the specified properties updated
+  func fluently(
+    debug: Optional<Bool> = .none,
+    trace: Optional<UUID> = .none,
+    source: Optional<PulseSource> = .none,
+    echoes: Optional<PulseSource> = .none,
+    priority: Optional<TaskPriority> = .none,
+    tags: Optional<Set<String>> = .none
+  ) -> PulseMeta {
+    return PulseMeta.Fluently(
+      self,
+      debug: debug,
+      trace: trace,
+      source: source,
+      echoes: echoes,
+      priority: priority,
+      tags: tags
+    )
+  }
+}

--- a/SablePulse/Source/Pulse.swift
+++ b/SablePulse/Source/Pulse.swift
@@ -69,20 +69,10 @@ public struct Pulse<Data: Pulsable>: Pulsable, Representable {
   }
   
   /// Private initializer used by the fluent builder pattern
-  private init(id: UUID, timestamp: Date, data: Data, meta: PulseMeta) {
+  internal init(id: UUID, timestamp: Date, data: Data, meta: PulseMeta) {
     self.id = id
     self.timestamp = timestamp
     self.data = data
     self.meta = meta
-  }
-  
-  /// Helper method for fluent builders to create new instances
-  internal static func Fluently(_ pulse: Pulse<Data>, meta: PulseMeta) -> Pulse<Data> {
-    return Pulse(
-      id: pulse.id,
-      timestamp: pulse.timestamp,
-      data: pulse.data,
-      meta: meta
-    )
   }
 }

--- a/SablePulse/Tests/Extensions/Pulse/PulseFluently.swift
+++ b/SablePulse/Tests/Extensions/Pulse/PulseFluently.swift
@@ -1,0 +1,227 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import SableFoundation
+
+@testable import SablePulse
+
+@Suite("SablePulse/Extensions/Pulse: Fluently")
+struct PulseFluencyTests {
+  
+  // MARK: - Test Data
+  
+  struct TestPulseData: Pulsable {
+    let value: String
+  }
+  
+  struct AlternateTestData: Pulsable {
+    let value: String
+  }
+  
+  // MARK: - Static Fluently Tests
+  
+  @Test("Fluently(_:) preserves pulse identity")
+  func fluently_static_preserves_pulse_identity() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    
+    // When
+    let updated = Pulse.Fluently(original)
+    
+    // Then
+    #expect(updated.id == original.id)
+    #expect(updated.timestamp == original.timestamp)
+  }
+  
+  @Test("Fluently(_:) preserves data when not specified")
+  func fluently_static_preserves_data_when_not_specified() throws {
+    // Given
+    let original_data = TestPulseData(value: "Original Data")
+    let original = Pulse(original_data)
+    
+    // When
+    let updated = Pulse.Fluently(original)
+    
+    // Then
+    #expect(updated.data.value == original_data.value)
+  }
+  
+  @Test("Fluently(_:) preserves metadata when not specified")
+  func fluently_static_preserves_metadata_when_not_specified() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    
+    // When
+    let updated = Pulse.Fluently(original)
+    
+    // Then
+    #expect(updated.meta.debug == original.meta.debug)
+    #expect(updated.meta.trace == original.meta.trace)
+    #expect(updated.meta.priority == original.meta.priority)
+    #expect(updated.meta.tags == original.meta.tags)
+  }
+  
+  @Test("Fluently(_:data:) updates data when specified")
+  func fluently_static_updates_data_when_specified() throws {
+    // Given
+    let original_data = TestPulseData(value: "Original Data")
+    let new_data = TestPulseData(value: "New Data")
+    let original = Pulse(original_data)
+    
+    // When
+    let updated = Pulse.Fluently(original, data: new_data)
+    
+    // Then
+    #expect(updated.data.value == "New Data")
+  }
+  
+  @Test("Fluently(_:meta:) updates metadata when specified")
+  func fluently_static_updates_metadata_when_specified() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    let new_meta = PulseMeta(debug: true, priority: .high, tags: ["test"])
+    
+    // When
+    let updated = Pulse.Fluently(original, meta: new_meta)
+    
+    // Then
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+    #expect(updated.meta.tags.contains("test"))
+  }
+  
+  @Test("Fluently(_:data:meta:) updates both when specified")
+  func fluently_static_updates_both_when_specified() throws {
+    // Given
+    let original_data = TestPulseData(value: "Original Data")
+    let new_data = TestPulseData(value: "New Data")
+    let original = Pulse(original_data)
+    let new_meta = PulseMeta(debug: true, priority: .high)
+    
+    // When
+    let updated = Pulse.Fluently(original, data: new_data, meta: new_meta)
+    
+    // Then
+    #expect(updated.data.value == "New Data")
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+  }
+  
+  // MARK: - Instance Fluently Tests
+  
+  @Test("fluently() preserves pulse identity")
+  func fluently_instance_preserves_pulse_identity() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    
+    // When
+    let updated = original.fluently()
+    
+    // Then
+    #expect(updated.id == original.id)
+    #expect(updated.timestamp == original.timestamp)
+  }
+  
+  @Test("fluently() preserves data when not specified")
+  func fluently_instance_preserves_data_when_not_specified() throws {
+    // Given
+    let original_data = TestPulseData(value: "Original Data")
+    let original = Pulse(original_data)
+    
+    // When
+    let updated = original.fluently()
+    
+    // Then
+    #expect(updated.data.value == original_data.value)
+  }
+  
+  @Test("fluently() preserves metadata when not specified")
+  func fluently_instance_preserves_metadata_when_not_specified() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    
+    // When
+    let updated = original.fluently()
+    
+    // Then
+    #expect(updated.meta.debug == original.meta.debug)
+    #expect(updated.meta.trace == original.meta.trace)
+    #expect(updated.meta.priority == original.meta.priority)
+    #expect(updated.meta.tags == original.meta.tags)
+  }
+  
+  @Test("fluently(data:) updates data when specified")
+  func fluently_instance_updates_data_when_specified() throws {
+    // Given
+    let original_data = TestPulseData(value: "Original Data")
+    let new_data = TestPulseData(value: "New Data")
+    let original = Pulse(original_data)
+    
+    // When
+    let updated = original.fluently(data: new_data)
+    
+    // Then
+    #expect(updated.data.value == "New Data")
+  }
+  
+  @Test("fluently(meta:) updates metadata when specified")
+  func fluently_instance_updates_metadata_when_specified() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    let new_meta = PulseMeta(debug: true, priority: .high, tags: ["test"])
+    
+    // When
+    let updated = original.fluently(meta: new_meta)
+    
+    // Then
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+    #expect(updated.meta.tags.contains("test"))
+  }
+  
+  @Test("fluently(data:meta:) updates both when specified")
+  func fluently_instance_updates_both_when_specified() throws {
+    // Given
+    let original_data = TestPulseData(value: "Original Data")
+    let new_data = TestPulseData(value: "New Data")
+    let original = Pulse(original_data)
+    let new_meta = PulseMeta(debug: true, priority: .high)
+    
+    // When
+    let updated = original.fluently(data: new_data, meta: new_meta)
+    
+    // Then
+    #expect(updated.data.value == "New Data")
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+  }
+  
+  // MARK: - Equality Tests
+  
+  @Test("fluently with no changes creates equal pulse")
+  func fluently_with_no_changes_creates_equal_pulse() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    
+    // When
+    let updated = original.fluently()
+    
+    // Then
+    #expect(updated == original)
+  }
+  
+  @Test("fluently with changes creates non-equal pulse")
+  func fluently_with_changes_creates_non_equal_pulse() throws {
+    // Given
+    let original = Pulse(TestPulseData(value: "Original"))
+    
+    // When
+    let updated = original.fluently(data: TestPulseData(value: "Modified"))
+    
+    // Then
+    #expect(updated != original)
+  }
+}

--- a/SablePulse/Tests/Extensions/PulseMeta/MetaFluently.swift
+++ b/SablePulse/Tests/Extensions/PulseMeta/MetaFluently.swift
@@ -1,0 +1,191 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import SableFoundation
+
+@testable import SablePulse
+
+@Suite("SablePulse/PulseMeta/Fluent")
+struct PulseMetaFluentTests {
+  
+  // MARK: - Helpers
+  
+  struct TestRepresentable: Representable {
+    let id = UUID()
+    let name = "Test Source"
+  }
+  
+  // MARK: - Static Fluently Method Tests
+  
+  @Test("Fluently preserves unmodified properties")
+  func fluently_preserves_unmodified_properties() throws {
+    // Given
+    let original = PulseMeta()
+    
+    // When
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    // Then
+    #expect(updated.trace == original.trace)
+    #expect(updated.source == original.source)
+    #expect(updated.echoes == original.echoes)
+    #expect(updated.priority == original.priority)
+    #expect(updated.tags == original.tags)
+  }
+  
+  @Test("Fluently updates debug flag")
+  func fluently_updates_debug_flag() throws {
+    // Given
+    let original = PulseMeta(debug: false)
+    
+    // When
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    // Then
+    #expect(original.debug == false)
+    #expect(updated.debug == true)
+  }
+  
+  @Test("Fluently updates trace")
+  func fluently_updates_trace() throws {
+    // Given
+    let original = PulseMeta()
+    let new_trace = UUID()
+    
+    // When
+    let updated = PulseMeta.Fluently(original, trace: new_trace)
+    
+    // Then
+    #expect(updated.trace == new_trace)
+  }
+  
+  @Test("Fluently updates source")
+  func fluently_updates_source() throws {
+    // Given
+    let original = PulseMeta()
+    let source = PulseSource.From(source: TestRepresentable())
+    
+    // When
+    let updated = PulseMeta.Fluently(original, source: source)
+    
+    // Then
+    #expect(updated.source?.id == source.id)
+  }
+  
+  @Test("Fluently updates echoes")
+  func fluently_updates_echoes() throws {
+    // Given
+    let original = PulseMeta()
+    let echo = PulseSource.From(source: TestRepresentable())
+    
+    // When
+    let updated = PulseMeta.Fluently(original, echoes: echo)
+    
+    // Then
+    #expect(updated.echoes?.id == echo.id)
+  }
+  
+  @Test("Fluently updates priority")
+  func fluently_updates_priority() throws {
+    // Given
+    let original = PulseMeta(priority: .low)
+    
+    // When
+    let updated = PulseMeta.Fluently(original, priority: .high)
+    
+    // Then
+    #expect(updated.priority == TaskPriority.high.rawValue)
+  }
+  
+  @Test("Fluently updates tags")
+  func fluently_updates_tags() throws {
+    // Given
+    let original = PulseMeta()
+    let new_tags: Set<String> = ["test", "fluent"]
+    
+    // When
+    let updated = PulseMeta.Fluently(original, tags: new_tags)
+    
+    // Then
+    #expect(updated.tags == new_tags)
+  }
+  
+  @Test("Fluently handles empty tags")
+  func fluently_handles_empty_tags() throws {
+    // Given
+    let original = PulseMeta(tags: ["original"])
+    let empty_tags: Set<String> = []
+    
+    // When
+    let updated = PulseMeta.Fluently(original, tags: empty_tags)
+    
+    // Then
+    #expect(updated.tags.isEmpty)
+  }
+  
+  // MARK: - Instance fluently Method Tests
+  
+  @Test("Instance fluently forwards to static Fluently")
+  func instance_fluently_forwards_to_static_fluently() throws {
+    // Given
+    let original = PulseMeta()
+    let debug = true
+    
+    // When - Both methods with same parameter
+    let static_result = PulseMeta.Fluently(original, debug: debug)
+    let instance_result = original.fluently(debug: debug)
+    
+    // Then
+    #expect(static_result.debug == instance_result.debug)
+  }
+  
+  @Test("Instance fluently enables method chaining")
+  func instance_fluently_enables_method_chaining() throws {
+    // Given
+    let original = PulseMeta()
+    
+    // When - Chain multiple individual property updates
+    let result = original
+      .fluently(debug: true)
+      .fluently(priority: .high)
+    
+    // Then
+    #expect(result.debug == true)
+    #expect(result.priority == TaskPriority.high.rawValue)
+  }
+  
+  @Test("Instance fluently maintains immutability")
+  func instance_fluently_maintains_immutability() throws {
+    // Given
+    let original = PulseMeta(debug: false, priority: .low)
+    
+    // When
+    let _ = original.fluently(debug: true, priority: .high)
+    
+    // Then - Original should be unchanged
+    #expect(original.debug == false)
+    #expect(original.priority == TaskPriority.low.rawValue)
+  }
+  
+  @Test("Instance fluently updates multiple properties in one call")
+  func instance_fluently_updates_multiple_properties() throws {
+    // Given
+    let original = PulseMeta()
+    let new_trace = UUID()
+    
+    // When
+    let updated = original.fluently(
+      debug: true,
+      trace: new_trace,
+      priority: .high
+    )
+    
+    // Then
+    #expect(updated.debug == true)
+    #expect(updated.trace == new_trace)
+    #expect(updated.priority == TaskPriority.high.rawValue)
+  }
+}


### PR DESCRIPTION
These support incoming internal fluent builders, which support the public API. <3