### PR TITLE
feat(pulse): static resppond and instance like

### DIFF
--- a/SablePulse/Source/Extensions/Pulse/FluentBuilder.swift
+++ b/SablePulse/Source/Extensions/Pulse/FluentBuilder.swift
@@ -107,4 +107,32 @@ extension Pulse {
     
     return fluently(meta: meta.fluently(tags: updated_tags))
   }
+  
+  // To be added to SablePulse/Source/Extensions/Pulse/FluentBuilder.swift
+  // after the existing extension methods
+  
+  /// Adopts all metadata from another pulse
+  ///
+  /// This method copies the complete metadata from the provided pulse while
+  /// preserving the current pulse's identity and data. Use it when you want
+  /// to create a pulse with identical operational characteristics to another.
+  ///
+  /// ```swift
+  /// // Create a new pulse with the same metadata as an existing one
+  /// let template_pulse = retrieve_template_pulse()
+  /// let new_pulse = Pulse(event_data).like(template_pulse)
+  /// ```
+  ///
+  /// All metadata properties are copied, including:
+  /// - Debug status
+  /// - Trace ID
+  /// - Source information
+  /// - Echoed pulse references
+  /// - Priority level
+  /// - Tags
+  ///
+  /// The original pulse's identity (ID and timestamp) and data are preserved.
+  public func like<T: Pulsable>(_ pulse: Pulse<T>) -> Pulse<Data> {
+    return fluently(meta: pulse.meta)
+  }
 }

--- a/SablePulse/Source/Extensions/Pulse/Respond.swift
+++ b/SablePulse/Source/Extensions/Pulse/Respond.swift
@@ -1,0 +1,55 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import SableFoundation
+
+/// Extension providing a static factory method for creating response pulses.
+///
+/// This extension adds a dedicated method for creating pulses that respond to
+/// other pulses, maintaining causal chains and trace information while providing
+/// a natural language interface.
+extension Pulse {
+  /// Creates a new pulse that responds to another pulse.
+  ///
+  /// This factory method creates a response pulse that:
+  /// - Maintains the same trace ID as the original pulse
+  /// - Sets the original pulse as the one being echoed
+  /// - Optionally sets a new source component
+  /// - Creates a new pulse ID and timestamp
+  ///
+  /// ```swift
+  /// // Create a simple response
+  /// let response = Pulse.Respond(to: original_pulse, with: completion_data)
+  ///
+  /// // Create a response with a specific source
+  /// let response = Pulse.Respond(to: original_pulse, with: result_data, from: processing_service)
+  /// ```
+  ///
+  /// Use this method when handling a pulse and generating a direct response
+  /// to preserve the causal relationship and contextual information needed
+  /// for tracing and debugging.
+  ///
+  /// - Parameters:
+  ///   - original: The pulse being responded to
+  ///   - data: The data payload for the response pulse
+  ///   - source: Optional source for the response (if nil, no source is set)
+  /// - Returns: A new pulse that echoes the original pulse
+  public static func Respond<Original: Pulsable>(
+    to original: Pulse<Original>,
+    with data: Data,
+    from source: Optional<any Representable> = .none
+  ) -> Pulse<Data> {
+    // Create a new pulse with the provided data
+    let pulse = Pulse(data).echoes(original)
+    
+    // If a source was provided, set it in the metadata
+    if let source = source {
+      return pulse.from(source)
+    }
+    
+    // Return a new pulse with the updated metadata
+    return pulse
+  }
+}

--- a/SablePulse/Tests/Extensions/Pulse/FluentBuilder.swift
+++ b/SablePulse/Tests/Extensions/Pulse/FluentBuilder.swift
@@ -273,6 +273,69 @@ struct PulseFluentTests {
     #expect(result.meta.tags.isEmpty)
   }
   
+  // MARK: - Like Tests
+  
+  @Test("like copies all metadata from source pulse")
+  func like_copies_all_metadata_from_source_pulse() throws {
+    // Given
+    struct OtherPulseData: Pulsable {
+      let id: Int
+    }
+    
+    let source_meta = PulseMeta(
+      debug: true,
+      trace: UUID(),
+      priority: .high,
+      tags: ["template", "reference"]
+    )
+    let source = Pulse(id: UUID(), timestamp: Date(), data: OtherPulseData(id: 42), meta: source_meta)
+    let target = create_test_pulse()
+    
+    // When
+    let result = target.like(source)
+    
+    // Then
+    #expect(result.meta.debug == source.meta.debug)
+    #expect(result.meta.trace == source.meta.trace)
+    #expect(result.meta.priority == source.meta.priority)
+    #expect(result.meta.tags == source.meta.tags)
+  }
+  
+  @Test("like preserves original pulse data")
+  func like_preserves_original_pulse_data() throws {
+    // Given
+    struct OtherPulseData: Pulsable {
+      let id: Int
+    }
+    
+    let source = Pulse(OtherPulseData(id: 42))
+    let target = Pulse(create_test_data(value: "Original Data"))
+    
+    // When
+    let result = target.like(source)
+    
+    // Then
+    #expect(result.data.value == "Original Data")
+  }
+  
+  @Test("like preserves original pulse identity")
+  func like_preserves_original_pulse_identity() throws {
+    // Given
+    struct OtherPulseData: Pulsable {
+      let id: Int
+    }
+    
+    let source = Pulse(OtherPulseData(id: 42))
+    let target = create_test_pulse()
+    
+    // When
+    let result = target.like(source)
+    
+    // Then
+    #expect(result.id == target.id)
+    #expect(result.timestamp == target.timestamp)
+  }
+  
   // MARK: - Chaining Tests
   
   @Test("chaining multiple methods works correctly")

--- a/SablePulse/Tests/Extensions/Pulse/Respond.swift
+++ b/SablePulse/Tests/Extensions/Pulse/Respond.swift
@@ -1,0 +1,223 @@
+// Copyright © 2025 Cassidy Spring. 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import SableFoundation
+
+@testable import SablePulse
+
+@Suite("SablePulse/Extensions: Pulse/Respond")
+struct PulseRespondTests {
+  
+  // MARK: - Test Data
+  
+  struct OriginalPulseData: Pulsable {
+    let message: String
+  }
+  
+  struct ResponsePulseData: Pulsable {
+    let success: Bool
+    let details: String
+  }
+  
+  struct TestSource: Representable {
+    let id = UUID()
+    let name = "Test Response Source"
+  }
+  
+  func create_original_pulse() -> Pulse<OriginalPulseData> {
+    return Pulse(OriginalPulseData(message: "Test Message"))
+  }
+  
+  func create_response_data() -> ResponsePulseData {
+    return ResponsePulseData(success: true, details: "Successfully processed")
+  }
+  
+  // MARK: - Basic Functionality Tests
+  
+  @Test("creates a new pulse with the provided data")
+  func creates_new_pulse_with_provided_data() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.data.success == true)
+    #expect(response.data.details == "Successfully processed")
+  }
+  
+  @Test("assigns a new UUID to the response pulse")
+  func assigns_new_uuid_to_response_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.id != original.id)
+  }
+  
+  @Test("sets a new timestamp on the response pulse")
+  func sets_new_timestamp_on_response_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let before = Date()
+    let response = Pulse.Respond(to: original, with: response_data)
+    let after = Date()
+    
+    // Then
+    #expect(response.timestamp != original.timestamp)
+    #expect(response.timestamp >= before)
+    #expect(response.timestamp <= after)
+  }
+  
+  // MARK: - Metadata Tests
+  
+  @Test("copies trace ID from original pulse")
+  func copies_trace_id_from_original_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.meta.trace == original.meta.trace)
+  }
+  
+  @Test("sets echoes reference to the original pulse")
+  func sets_echoes_reference_to_original_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.meta.echoes != nil)
+    #expect(response.meta.echoes?.id == original.id)
+    #expect(response.meta.echoes?.name == original.name)
+  }
+  
+  @Test("does not set source when none is provided")
+  func does_not_set_source_when_none_provided() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.meta.source == nil)
+  }
+  
+  @Test("sets source when one is provided")
+  func sets_source_when_one_provided() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    let source = TestSource()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data, from: source)
+    
+    // Then
+    #expect(response.meta.source != nil)
+    #expect(response.meta.source?.id == source.id)
+    #expect(response.meta.source?.name == source.name)
+  }
+  
+  // MARK: - Cross-Type Tests
+  
+  @Test("works with different data types")
+  func works_with_different_data_types() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(type(of: original.data) == OriginalPulseData.self)
+    #expect(type(of: response.data) == ResponsePulseData.self)
+  }
+  
+  // MARK: - Complex Scenarios
+  
+  @Test("preserves original pulse debug flag")
+  func preserves_original_pulse_debug_flag() throws {
+    // Given
+    let original = create_original_pulse().debug(true)
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    // Debug flag should NOT be preserved - only trace and echoes are copied
+    #expect(response.meta.debug == false)
+  }
+  
+  @Test("preserves original pulse priority")
+  func preserves_original_pulse_priority() throws {
+    // Given
+    let original = create_original_pulse().priority(.high)
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    // Priority should NOT be preserved - only trace and echoes are copied
+    #expect(response.priority == .medium) // Default value
+  }
+  
+  @Test("preserves original pulse tags")
+  func preserves_original_pulse_tags() throws {
+    // Given
+    let original = create_original_pulse().tagged("important", "test")
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    // Tags should NOT be preserved - only trace and echoes are copied
+    #expect(response.meta.tags.isEmpty)
+  }
+  
+  @Test("can be combined with other fluent methods")
+  func can_be_combined_with_other_fluent_methods() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+      .debug(true)
+      .priority(.high)
+      .tagged("response", "processed")
+    
+    // Then
+    #expect(response.meta.debug == true)
+    #expect(response.priority == .high)
+    #expect(response.meta.tags.contains("response"))
+    #expect(response.meta.tags.contains("processed"))
+    #expect(response.meta.trace == original.meta.trace)
+    #expect(response.meta.echoes?.id == original.id)
+  }
+}


### PR DESCRIPTION
Additions to the public API for creating pulses. Respond is a common case of creating a base pulse that echoes another, it's really a convenience method. The instance `like` method is useful for batch pulses or other cases where the majority of (corrected with chaining) or all metadata is useful to copy.