### PR TITLE
ci(codecov): setup codecov reports

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,4 +52,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./.build/arm64-apple-macos/debug/codecov/Sable.json
+          files: ./.build/arm64-apple-macosx/debug/codecov/Sable.json

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,3 +52,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          directory: .build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,14 +28,8 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v4
-      - name: build
-        run: swift build
       - name: test
         run: swift test --parallel --enable-code-coverage
-      - name: coverage
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   coverage:
     runs-on: macos-latest
@@ -44,12 +38,12 @@ jobs:
         with:
           swift-version: "6.1"
       - uses: actions/checkout@v4
-      - name: build
-        run: swift build
       - name: test
         run: swift test --parallel --enable-code-coverage
+      - name: report
+        run: xcrun llvm-cov export -format="lcov" .build/debug/SablePackageTests.xctest/Contents/MacOS/SablePackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
       - name: coverage
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./.build/arm64-apple-macosx/debug/codecov/Sable.json
+          files: ./coverage.lcov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,4 +31,24 @@ jobs:
       - name: build
         run: swift build
       - name: test
-        run: swift test
+        run: swift test --parallel --enable-code-coverage
+      - name: coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  coverage:
+    runs-on: macos-latest
+    steps:
+      - uses: swift-actions/setup-swift@v2.3.0
+        with:
+          swift-version: "6.1"
+      - uses: actions/checkout@v4
+      - name: build
+        run: swift build
+      - name: test
+        run: swift test --parallel --enable-code-coverage
+      - name: coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
       - name: test
         run: swift test --parallel --enable-code-coverage
       - name: report
-        run: xcrun llvm-cov export -format="lcov" .build/debug/SablePackageTests.xctest/Contents/MacOS/SablePackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
+        run: xcrun llvm-cov export -format="lcov" .build/arm64-apple-macosx/debug/SablePackageTests.xctest/Contents/MacOS/SablePackageTests -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata > coverage.lcov
       - name: coverage
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,14 +34,14 @@ jobs:
   coverage:
     runs-on: macos-latest
     steps:
-      - uses: swift-actions/setup-swift@v2.3.0
+      - uses: maxim-lobanov/setup-xcode@v1
         with:
-          swift-version: "6.0"
+          xcode-version: latest-stable
       - uses: actions/checkout@v4
       - name: test
         run: swift test --parallel --enable-code-coverage
       - name: report
-        run: xcrun llvm-cov export -format="lcov" .build/arm64-apple-macosx/debug/SablePackageTests.xctest/Contents/MacOS/SablePackageTests -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata > coverage.lcov
+        run: xcrun llvm-cov export -format=lcov .build/arm64-apple-macosx/debug/SablePackageTests.xctest/Contents/MacOS/SablePackageTests -instr-profile .build/arm64-apple-macosx/debug/codecov/default.profdata --ignore-filename-regex=".build" > coverage.lcov
       - name: coverage
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,4 +52,4 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: .build
+          files: ./.build/arm64-apple-macos/debug/codecov/Sable.json

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: swift-actions/setup-swift@v2.3.0
         with:
-          swift-version: "6.1"
+          swift-version: "6.0"
       - uses: actions/checkout@v4
       - name: test
         run: swift test --parallel --enable-code-coverage

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fbeeauvin%2FSable%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/beeauvin/Sable)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fbeeauvin%2FSable%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/beeauvin/Sable)
+[![tests](https://github.com/beeauvin/Sable/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/beeauvin/Sable/actions/workflows/continuous-integration.yml)
+[![codecov](https://codecov.io/gh/beeauvin/Sable/graph/badge.svg?token=tHGLyrd7rG)](https://codecov.io/gh/beeauvin/Sable)
 [![Maintainability](https://qlty.sh/badges/746fd841-b456-4854-9560-4603ba3660fb/maintainability.svg)](https://qlty.sh/gh/beeauvin/projects/Sable)
 
 🖤 Sable is a Swift 6+ utility library that prioritizes beautiful API design


### PR DESCRIPTION
i don't actually expect this to work on the first attempt but, here we go. Running the whole build/test for `macos-latest` isn't great but i don't want to run codecov for the whole matrix either. C'est la vie.