### PR TITLE
feat(package): mark support for current platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,10 @@ let package = Package(
   name: "Sable",
   platforms: [
     .macOS(.v14),
+    .iOS(.v18),
+    .tvOS(.v18),
+    .visionOS(.v2),
+    .watchOS(.v11),
   ],
   products: [
     .library(name: "Sable", targets: ["Sable"])


### PR DESCRIPTION
Following https://endoflife.date/ios as a general guide. I have no intention of supporting OS versions that are no longer receiving security updates; preferably also only OSes I can test against. Unfortunately I can't find a great source on this from Apple and automated testing for their various platforms seems... Difficult, at best.

So for the moment I'll follow the most reasonable guide I can. Release cycle for Sable (and other packages of mine) will update major versions for platform support changes. In this case none of these were supported to begin with so, there's that.