### PR TITLE
feat(channel): channel implementation

### DIFF
--- a/Sources/Channel/Channel.swift
+++ b/Sources/Channel/Channel.swift
@@ -1,0 +1,183 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Obsidian
+
+/// A typed message handler that delivers pulses to a registered handler function.
+///
+/// `Channel` provides a safe, actor-isolated mechanism for delivering strongly-typed
+/// pulse messages to registered handlers. It implements an ownership model where only
+/// the component that created the channel can release it, ensuring that channels
+/// remain active as long as needed by their owners.
+///
+/// Channels guarantee that any pulse sent to an unreleased channel will be delivered
+/// to its handler, even if the handler executes asynchronously. Each delivered pulse
+/// maintains its specified priority through the handling chain.
+///
+/// ```swift
+/// // Create a channel with a generated key
+/// let (auth_channel, auth_key) = Channel.Create { pulse in
+///   await process_auth_event(pulse.data)
+/// }
+///
+/// // Create a channel owned by a specific component
+/// let profile_channel = Channel(owner: profile_service) { pulse in
+///   await update_user_profile(pulse.data)
+/// }
+///
+/// // Create a channel with a custom key
+/// let custom_key = UUID()
+/// let notification_channel = Channel(key: custom_key) { pulse in
+///   await send_push_notification(pulse.data)
+/// }
+/// ```
+///
+/// Channels use a fire-and-forget model for pulse delivery, spawning tasks that
+/// inherit the priority of the pulse being processed. This approach ensures that
+/// channel operations remain non-blocking while maintaining appropriate prioritization.
+final public actor Channel<Data: Pulsable> {
+  /// Internal reference to the handler this Channel will send pulses to.
+  private var handler: Optional<ChannelHandler<Data>>
+  
+  /// Internal key for release verification.
+  private let key: UUID
+  
+  /// Creates a new channel with the specified key and handler function.
+  ///
+  /// This initializer creates a channel that can only be released by providing
+  /// the same key used during creation, establishing a simple ownership model.
+  ///
+  /// ```swift
+  /// let channel_key = UUID()
+  /// let event_channel = Channel(key: channel_key) { pulse in
+  ///   await event_processor.handle(pulse.data)
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - key: The unique identifier that authorizes channel release
+  ///   - handler: The function that will process pulses sent to this channel
+  public init(key: UUID, handler: @escaping ChannelHandler<Data>) {
+    self.handler = handler
+    self.key = key
+  }
+  
+  /// Creates a new channel owned by a specific component.
+  ///
+  /// This convenience initializer uses the owner's unique identifier as the
+  /// channel key, simplifying channel creation for components that already
+  /// implement the `Uniquable` protocol.
+  ///
+  /// ```swift
+  /// let service_channel = Channel(owner: auth_service) { pulse in
+  ///   await process_auth_event(pulse.data)
+  /// }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - owner: The component that owns this channel
+  ///   - handler: The function that will process pulses sent to this channel
+  public init(owner: any Uniquable, handler: @escaping ChannelHandler<Data>) {
+    self.handler = handler
+    self.key = owner.id
+  }
+
+  /// Creates a new channel with a generated key and returns both the channel and key.
+  ///
+  /// This factory method generates a new UUID to serve as the channel key, then
+  /// returns both the created channel and the key. This pattern is useful when
+  /// the caller needs to create and own a channel without having a pre-existing
+  /// unique identifier.
+  ///
+  /// ```swift
+  /// let (channel, key) = Channel.Create { pulse in
+  ///   await process_data(pulse.data)
+  /// }
+  ///
+  /// // Later, release the channel using the returned key
+  /// await channel.release(key: key)
+  /// ```
+  ///
+  /// - Parameter handler: The function that will process pulses sent to this channel
+  /// - Returns: A tuple containing the new channel and its authorization key
+  public static func Create(handler: @escaping ChannelHandler<Data>) -> (channel: Channel<Data>, key: UUID) {
+    let key = UUID()
+    return (Channel(key: key, handler: handler), key)
+  }
+  
+  /// Sends a pulse to this channel for processing.
+  ///
+  /// This method delivers the provided pulse to the channel's registered handler
+  /// function. Delivery happens asynchronously in a separate task that inherits
+  /// the priority of the pulse, ensuring that high-priority pulses are processed
+  /// appropriately. If the channel has been released, the operation fails with
+  /// a `.released` error.
+  ///
+  /// ```swift
+  /// let result = await channel.send(login_pulse)
+  ///
+  /// if case .failure(.released) = result {
+  ///   // Channel was released, handle accordingly
+  ///   reconnect_channel()
+  /// }
+  /// ```
+  ///
+  /// The channel guarantees that if it hasn't been released, the pulse will be
+  /// delivered to the handler, even if the handler executes asynchronously.
+  ///
+  /// - Parameter pulse: The typed pulse to send to this channel
+  /// - Returns: A result indicating success or a specific channel error
+  @discardableResult
+  public func send(_ pulse: Pulse<Data>) async -> ChannelResult {
+    return self.handler.transform { handler in
+      Task(priority: pulse.priority) { await handler(pulse) }
+      return ChannelResult.success(())
+    }.otherwise(ChannelResult.failure(.released))
+  }
+
+  /// Releases this channel, preventing further pulse processing.
+  ///
+  /// This method deactivates the channel by clearing its handler reference,
+  /// preventing any further pulses from being processed. To ensure that only
+  /// the channel owner can release it, the provided key must match the key
+  /// used during channel creation.
+  ///
+  /// ```swift
+  /// // Release a channel using its key
+  /// let result = await channel.release(key: channel_key)
+  ///
+  /// switch result {
+  /// case .success:
+  ///   log_event("Channel successfully released")
+  ///
+  /// case .failure(.released):
+  ///   log_warning("Channel was already released")
+  ///
+  /// case .failure(.invalid(let key)):
+  ///   log_security_event("Invalid key used: \(key)")
+  /// }
+  /// ```
+  ///
+  /// If the channel has already been released, the operation fails with a
+  /// `.released` error. If the provided key doesn't match the channel's key,
+  /// the operation fails with an `.invalid` error containing the provided key.
+  ///
+  /// - Parameter key: The authorization key that must match the channel's key
+  /// - Returns: A result indicating success or a specific channel error
+  @discardableResult
+  public func release(key: UUID) async -> ChannelResult {
+    return self.handler.transform { handler in
+      guard self.key == key else { return ChannelResult.failure(.invalid(key: key)) }
+      self.handler = .none
+      return ChannelResult.success(())
+    }.otherwise(ChannelResult.failure(.released))
+  }
+  
+  /// Generally the release method should be called. There are some cases where this
+  /// can be relied on instead when no reference cycles are created.
+  deinit {
+    handler = .none
+  }
+}

--- a/Sources/Channel/Types/ChannelError.swift
+++ b/Sources/Channel/Types/ChannelError.swift
@@ -1,0 +1,50 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Obsidian
+
+/// Represents specific error conditions that can occur during channel operations.
+///
+/// `ChannelError` encapsulates the two primary failure modes for channel operations:
+/// - When attempting to interact with a channel that has been released
+/// - When attempting to release a channel with an invalid authorization key
+///
+/// These errors are returned as part of a `ChannelResult` rather than thrown,
+/// aligning with Sable's design principle of non-throwing code. This approach
+/// encourages explicit error handling and predictable control flow.
+///
+/// ```swift
+/// // Handle channel errors in a switch statement
+/// switch result {
+/// case .success:
+///   continue_processing()
+///
+/// case .failure(.released):
+///   reconnect_channel()
+///
+/// case .failure(.invalid(let key)):
+///   log_security_event("Invalid key used: \(key)")
+/// }
+/// ```
+///
+/// The error cases are designed to provide just enough context for proper error
+/// handling without exposing unnecessary implementation details.
+@frozen public enum ChannelError: Error {
+  /// Indicates that the channel has been released and can no longer process pulses.
+  ///
+  /// This error occurs when attempting to send a pulse to a channel that has been
+  /// explicitly released, or when attempting to release a channel that has
+  /// already been released.
+  case released
+  
+  /// Indicates that an invalid key was provided when attempting to release a channel.
+  ///
+  /// To prevent unauthorized release of channels, a security key must be provided
+  /// that matches the key used during channel creation. This error includes the
+  /// invalid key that was provided, which can be useful for security auditing.
+  ///
+  /// - Parameter key: The invalid UUID that was provided during the release attempt
+  case invalid(key: UUID)
+}

--- a/Sources/Channel/Types/ChannelHandler.swift
+++ b/Sources/Channel/Types/ChannelHandler.swift
@@ -1,0 +1,33 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Type alias that defines a handler function for processing pulses within a channel.
+///
+/// `ChannelHandler` represents an asynchronous function that consumes pulses through
+/// a channel. Each handler:
+/// - Takes a strongly-typed pulse as input
+/// - Executes asynchronously to ensure non-blocking operations
+/// - Returns nothing (Void), focusing exclusively on processing the pulse
+/// - Conforms to Sendable to enable safe concurrent execution across actor boundaries
+///
+/// Channel handlers are designed to be registered with a channel to process all
+/// pulses sent through that specific channel. They act as the terminal processor in a
+/// pulse's journey through the messaging system.
+///
+/// ```swift
+/// // Define a simple handler that logs pulse information
+/// let logging_handler: ChannelHandler<LoginEvent> = { pulse in
+///   await logger.log("Received login event: \(pulse.data.user_id)")
+/// }
+///
+/// // Define a handler that forwards pulses to another system
+/// let forwarding_handler: ChannelHandler<SystemEvent> = { pulse in
+///   await external_system.process(pulse)
+/// }
+/// ```
+///
+/// Handlers automatically inherit the priority of the pulse being processed,
+/// ensuring that high-priority pulses receive appropriately prioritized handling.
+public typealias ChannelHandler<Data: Pulsable> = @Sendable (Pulse<Data>) async -> Void

--- a/Sources/Channel/Types/ChannelResult.swift
+++ b/Sources/Channel/Types/ChannelResult.swift
@@ -1,0 +1,38 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Type alias representing the result of a channel operation.
+///
+/// `ChannelResult` provides a standardized way to handle the outcome of operations
+/// performed on a channel, such as sending a pulse or releasing a channel. The Result
+/// type encapsulates either success (Void) or failure with a specific ChannelError.
+///
+/// Using Result instead of throwing functions aligns with Sable's design principle
+/// of non-throwing code, allowing for explicit error handling patterns that are both
+/// predictable and composable.
+///
+/// ```swift
+/// // Process a channel operation result
+/// let result = await channel.send(pulse)
+///
+/// switch result {
+/// case .success:
+///   // Operation succeeded
+///   break
+///
+/// case .failure(.released):
+///   // Channel was already released
+///   handle_released_channel()
+///
+/// case .failure(.invalid(let key)):
+///   // Invalid key was provided
+///   log_invalid_key_error(key)
+/// }
+/// ```
+///
+/// Channel operations typically return this result type, allowing callers
+/// to determine whether the operation completed successfully or encountered
+/// a specific error condition.
+public typealias ChannelResult = Result<Void, ChannelError>

--- a/Tests/ChannelTests/ChannelTests.swift
+++ b/Tests/ChannelTests/ChannelTests.swift
@@ -1,0 +1,220 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import Sable
+
+@Suite("Sable/Channel/Core: Channel")
+struct ChannelTests {
+  
+  // MARK: - Test Data
+  
+  struct TestPulseData: Pulsable {
+    let message: String
+  }
+  
+  struct TestOwner: Uniquable {
+    let id = UUID()
+    let name = "Test Owner"
+  }
+  
+  func create_test_pulse() -> Pulse<TestPulseData> {
+    return Pulse(TestPulseData(message: "Test Message"))
+  }
+  
+  // MARK: - Initialization Tests
+  
+  @Test("initializes with provided key")
+  func initializes_with_provided_key() throws {
+    // Given
+    let key = UUID()
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    // When
+    let _ = Channel(key: key, handler: handler)
+    
+    // Then
+    // If initialization failed, this would have thrown an error
+    // No assertion needed - the test passes if no error is thrown
+  }
+  
+  @Test("initializes with owner")
+  func initializes_with_owner() throws {
+    // Given
+    let owner = TestOwner()
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    // When
+    let _ = Channel(owner: owner, handler: handler)
+    
+    // Then
+    // If initialization failed, this would have thrown an error
+    // No assertion needed - the test passes if no error is thrown
+  }
+  
+  @Test("Create returns channel and key")
+  func create_returns_channel_and_key() throws {
+    // Given
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    // When
+    let (_, key) = Channel.Create(handler: handler)
+    
+    // Then
+    #expect(!key.uuidString.isEmpty)
+  }
+  
+  // MARK: - Send Tests
+  
+  @Test("send delivers pulse to handler")
+  func send_delivers_pulse_to_handler() async throws {
+    // Given
+    let pulse = create_test_pulse()
+    let expected_message = pulse.data.message
+    
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestPulseData> = { received_pulse in
+        #expect(received_pulse.data.message == expected_message)
+        confirm()
+      }
+      
+      let channel = Channel(key: UUID(), handler: handler)
+      let result = await channel.send(pulse)
+      try await Task.sleep(for: .milliseconds(100))
+      
+      if case .success = result {
+        // Success case verified
+      } else {
+        #expect(Bool(false), "Expected success result from send")
+      }
+    }
+  }
+  
+  @Test("send returns error when channel is released")
+  func send_returns_error_when_channel_released() async throws {
+    // Given
+    let pulse = create_test_pulse()
+    let key = UUID()
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    let channel = Channel(key: key, handler: handler)
+    
+    // When
+    let release_result = await channel.release(key: key)
+    if case .failure = release_result {
+      #expect(Bool(false), "Channel release should have succeeded")
+    }
+    
+    // Then
+    let send_result = await channel.send(pulse)
+    
+    if case .failure(let error) = send_result {
+      if case .released = error {
+        // Success - got the released error as expected
+      } else {
+        #expect(Bool(false), "Expected released error but got different error")
+      }
+    } else {
+      #expect(Bool(false), "Expected failure result from send")
+    }
+  }
+  
+  // MARK: - Release Tests
+  
+  @Test("release succeeds with correct key")
+  func release_succeeds_with_correct_key() async throws {
+    // Given
+    let key = UUID()
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    let channel = Channel(key: key, handler: handler)
+    
+    // When
+    let result = await channel.release(key: key)
+    
+    // Then
+    if case .success = result {
+      // Success case verified
+    } else {
+      #expect(Bool(false), "Expected success result from release")
+    }
+  }
+  
+  @Test("release fails with incorrect key")
+  func release_fails_with_incorrect_key() async throws {
+    // Given
+    let correct_key = UUID()
+    let incorrect_key = UUID()
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    let channel = Channel(key: correct_key, handler: handler)
+    
+    // When
+    let result = await channel.release(key: incorrect_key)
+    
+    // Then
+    if case .failure(let error) = result {
+      if case .invalid(let key) = error {
+        #expect(key == incorrect_key)
+      } else {
+        #expect(Bool(false), "Expected invalid key error but got different error")
+      }
+    } else {
+      #expect(Bool(false), "Expected failure result from release")
+    }
+  }
+  
+  @Test("release fails when already released")
+  func release_fails_when_already_released() async throws {
+    // Given
+    let key = UUID()
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    let channel = Channel(key: key, handler: handler)
+    
+    // When
+    let first_result = await channel.release(key: key)
+    if case .failure = first_result {
+      #expect(Bool(false), "First channel release should have succeeded")
+    }
+    
+    // Then
+    let second_result = await channel.release(key: key)
+    
+    if case .failure(let error) = second_result {
+      if case .released = error {
+        // Success - got the released error as expected
+      } else {
+        #expect(Bool(false), "Expected released error but got different error")
+      }
+    } else {
+      #expect(Bool(false), "Expected failure result from second release")
+    }
+  }
+  
+  // MARK: - Task Priority Tests
+  
+  @Test("send creates task with pulse priority")
+  func send_creates_task_with_pulse_priority() async throws {
+    // Given
+    let pulse = create_test_pulse().priority(.high)
+    
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestPulseData> = { _ in
+        let current_priority = Task.currentPriority
+        #expect(current_priority == .high)
+        confirm()
+      }
+      
+      let channel = Channel(key: UUID(), handler: handler)
+      let _ = await channel.send(pulse)
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+}


### PR DESCRIPTION
Channel is the primary building block of Sable's entire pulse delivery framework; using chain-of-trust to build upon this core contract.