### PR TITLE
deps(obsidian): update to v0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     .library(name: "Sable", targets: ["Sable"])
   ],
   dependencies: [
-    .package(url: "https://github.com/beeauvin/Obsidian.git", exact: "0.1.0")
+    .package(url: "https://github.com/beeauvin/Obsidian.git", exact: "0.2.0")
   ],
   targets: [
     .target(name: "Sable", dependencies: ["Obsidian"], path: "Sources"),


### PR DESCRIPTION
Includes lots of Result features that incoming Sable features (from the private version) use heavily. This is required to move forward.