### PR TITLE
build(platform): actual compatibility?

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,11 @@ import PackageDescription
 let package = Package(
   name: "Sable",
   platforms: [
-    .macOS(.v14),
-    .iOS(.v18),
-    .tvOS(.v18),
-    .visionOS(.v2),
-    .watchOS(.v11),
+    .macOS(.v10_15),
+    .iOS(.v13),
+    .tvOS(.v13),
+    .visionOS(.v1),
+    .watchOS(.v6),
   ],
   products: [
     .library(name: "Sable", targets: ["Sable"])


### PR DESCRIPTION
Ok so I learned how to -actually- check this when working on Obsidian (yay, good job Bee! 😝). So these are the minimum platforms that Sable builds against. Don't love it, but it's fine. This is fine.

This may very well change again before Sable hits v1.0 and I still don't particularly love supporting platforms that aren't getting security updates anymore but... C'est la vie...