### PR TITLE
feat(channel): breaking - remove key based release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     .library(name: "Sable", targets: ["Sable"])
   ],
   dependencies: [
-    .package(url: "https://github.com/beeauvin/Obsidian.git", exact: "0.2.0")
+    .package(url: "https://github.com/beeauvin/Obsidian.git", exact: "0.2.1")
   ],
   targets: [
     .target(name: "Sable", dependencies: ["Obsidian"], path: "Sources"),

--- a/Sources/Channel/Channel.swift
+++ b/Sources/Channel/Channel.swift
@@ -8,103 +8,41 @@ import Obsidian
 /// A typed message handler that delivers pulses to a registered handler function.
 ///
 /// `Channel` provides a safe, actor-isolated mechanism for delivering strongly-typed
-/// pulse messages to registered handlers. It implements an ownership model where only
-/// the component that created the channel can release it, ensuring that channels
-/// remain active as long as needed by their owners.
+/// pulse messages to registered handlers. It implements a simple ownership model
+/// where the component that has a reference to the channel can release it when needed.
 ///
 /// Channels guarantee that any pulse sent to an unreleased channel will be delivered
 /// to its handler, even if the handler executes asynchronously. Each delivered pulse
 /// maintains its specified priority through the handling chain.
 ///
 /// ```swift
-/// // Create a channel with a generated key
-/// let (auth_channel, auth_key) = Channel.Create { pulse in
+/// // Create a channel with a handler
+/// let auth_channel = Channel { pulse in
 ///   await process_auth_event(pulse.data)
-/// }
-///
-/// // Create a channel owned by a specific component
-/// let profile_channel = Channel(owner: profile_service) { pulse in
-///   await update_user_profile(pulse.data)
-/// }
-///
-/// // Create a channel with a custom key
-/// let custom_key = UUID()
-/// let notification_channel = Channel(key: custom_key) { pulse in
-///   await send_push_notification(pulse.data)
 /// }
 /// ```
 ///
 /// Channels use a fire-and-forget model for pulse delivery, spawning tasks that
 /// inherit the priority of the pulse being processed. This approach ensures that
 /// channel operations remain non-blocking while maintaining appropriate prioritization.
-final public actor Channel<Data: Pulsable> {
+final public actor Channel<Data: Pulsable>: Channeling {
   /// Internal reference to the handler this Channel will send pulses to.
   private var handler: Optional<ChannelHandler<Data>>
   
-  /// Internal key for release verification.
-  private let key: UUID
-  
-  /// Creates a new channel with the specified key and handler function.
+  /// Creates a new channel with the specified handler function.
   ///
-  /// This initializer creates a channel that can only be released by providing
-  /// the same key used during creation, establishing a simple ownership model.
+  /// This initializer creates a channel that can be released by any code
+  /// with a reference to it, following Swift's standard ownership model.
   ///
   /// ```swift
-  /// let channel_key = UUID()
-  /// let event_channel = Channel(key: channel_key) { pulse in
+  /// let event_channel = Channel { pulse in
   ///   await event_processor.handle(pulse.data)
   /// }
   /// ```
   ///
-  /// - Parameters:
-  ///   - key: The unique identifier that authorizes channel release
-  ///   - handler: The function that will process pulses sent to this channel
-  public init(key: UUID, handler: @escaping ChannelHandler<Data>) {
-    self.handler = handler
-    self.key = key
-  }
-  
-  /// Creates a new channel owned by a specific component.
-  ///
-  /// This convenience initializer uses the owner's unique identifier as the
-  /// channel key, simplifying channel creation for components that already
-  /// implement the `Uniquable` protocol.
-  ///
-  /// ```swift
-  /// let service_channel = Channel(owner: auth_service) { pulse in
-  ///   await process_auth_event(pulse.data)
-  /// }
-  /// ```
-  ///
-  /// - Parameters:
-  ///   - owner: The component that owns this channel
-  ///   - handler: The function that will process pulses sent to this channel
-  public init(owner: any Uniquable, handler: @escaping ChannelHandler<Data>) {
-    self.handler = handler
-    self.key = owner.id
-  }
-
-  /// Creates a new channel with a generated key and returns both the channel and key.
-  ///
-  /// This factory method generates a new UUID to serve as the channel key, then
-  /// returns both the created channel and the key. This pattern is useful when
-  /// the caller needs to create and own a channel without having a pre-existing
-  /// unique identifier.
-  ///
-  /// ```swift
-  /// let (channel, key) = Channel.Create { pulse in
-  ///   await process_data(pulse.data)
-  /// }
-  ///
-  /// // Later, release the channel using the returned key
-  /// await channel.release(key: key)
-  /// ```
-  ///
   /// - Parameter handler: The function that will process pulses sent to this channel
-  /// - Returns: A tuple containing the new channel and its authorization key
-  public static func Create(handler: @escaping ChannelHandler<Data>) -> (channel: Channel<Data>, key: UUID) {
-    let key = UUID()
-    return (Channel(key: key, handler: handler), key)
+  public init(handler: @escaping ChannelHandler<Data>) {
+    self.handler = handler
   }
   
   /// Sends a pulse to this channel for processing.
@@ -133,45 +71,33 @@ final public actor Channel<Data: Pulsable> {
   public func send(_ pulse: Pulse<Data>) async -> ChannelResult {
     return self.handler.transform { handler in
       Task(priority: pulse.priority) { await handler(pulse) }
-      return ChannelResult.success(())
+      return ChannelResult.success
     }.otherwise(ChannelResult.failure(.released))
   }
-
+  
   /// Releases this channel, preventing further pulse processing.
   ///
   /// This method deactivates the channel by clearing its handler reference,
-  /// preventing any further pulses from being processed. To ensure that only
-  /// the channel owner can release it, the provided key must match the key
-  /// used during channel creation.
+  /// preventing any further pulses from being processed.
   ///
   /// ```swift
-  /// // Release a channel using its key
-  /// let result = await channel.release(key: channel_key)
+  /// // Release a channel
+  /// let result = await channel.release()
   ///
-  /// switch result {
-  /// case .success:
-  ///   log_event("Channel successfully released")
-  ///
-  /// case .failure(.released):
+  /// if case .failure(.released) = result {
   ///   log_warning("Channel was already released")
-  ///
-  /// case .failure(.invalid(let key)):
-  ///   log_security_event("Invalid key used: \(key)")
   /// }
   /// ```
   ///
   /// If the channel has already been released, the operation fails with a
-  /// `.released` error. If the provided key doesn't match the channel's key,
-  /// the operation fails with an `.invalid` error containing the provided key.
+  /// `.released` error.
   ///
-  /// - Parameter key: The authorization key that must match the channel's key
   /// - Returns: A result indicating success or a specific channel error
   @discardableResult
-  public func release(key: UUID) async -> ChannelResult {
+  public func release() async -> ChannelResult {
     return self.handler.transform { handler in
-      guard self.key == key else { return ChannelResult.failure(.invalid(key: key)) }
       self.handler = .none
-      return ChannelResult.success(())
+      return ChannelResult.success
     }.otherwise(ChannelResult.failure(.released))
   }
   

--- a/Sources/Channel/Protocols/Channeling.swift
+++ b/Sources/Channel/Protocols/Channeling.swift
@@ -1,0 +1,55 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Obsidian
+
+/// A protocol that defines the core operations for channel-like components.
+///
+/// `Channeling` standardizes the interface for any component that provides
+/// channel-like functionality, whether directly implementing a channel or
+/// wrapping one. This allows for consistent usage patterns and enables
+/// composition and delegation without tight coupling to the concrete `Channel` type.
+///
+/// Implementers of this protocol must provide the ability to:
+/// - Send a strongly-typed pulse to a handler
+/// - Release the channel, preventing further message processing
+///
+/// Both operations return a `ChannelResult` to enable proper error handling.
+///
+/// ```swift
+/// struct ChannelWrapper<Data: Pulsable>: Channeling {
+///   private let inner_channel: Channel<Data>
+///
+///   init(handler: @escaping ChannelHandler<Data>) {
+///     self.inner_channel = Channel(handler: handler)
+///   }
+///
+///   func send(_ pulse: Pulse<Data>) async -> ChannelResult {
+///     return await inner_channel.send(pulse)
+///   }
+///
+///   func release() async -> ChannelResult {
+///     return await inner_channel.release()
+///   }
+/// }
+/// ```
+///
+/// This protocol enables building more complex channel-based architectures
+/// through composition and wrapping, while maintaining a consistent interface.
+public protocol Channeling<Data> {
+  /// The type of data this channel can handle
+  associatedtype Data: Pulsable
+  
+  /// Sends a pulse to this channel for processing.
+  ///
+  /// - Parameter pulse: The typed pulse to send through this channel
+  /// - Returns: A result indicating success or a specific channel error
+  func send(_ pulse: Pulse<Data>) async -> ChannelResult
+  
+  /// Releases this channel, preventing further pulse processing.
+  ///
+  /// - Returns: A result indicating success or a specific channel error
+  func release() async -> ChannelResult
+}

--- a/Sources/Channel/Types/ChannelError.swift
+++ b/Sources/Channel/Types/ChannelError.swift
@@ -7,11 +7,10 @@ import Obsidian
 
 /// Represents specific error conditions that can occur during channel operations.
 ///
-/// `ChannelError` encapsulates the two primary failure modes for channel operations:
-/// - When attempting to interact with a channel that has been released
-/// - When attempting to release a channel with an invalid authorization key
+/// `ChannelError` encapsulates the primary failure mode for channel operations:
+/// attempting to interact with a channel that has been released.
 ///
-/// These errors are returned as part of a `ChannelResult` rather than thrown,
+/// This error is returned as part of a `ChannelResult` rather than thrown,
 /// aligning with Sable's design principle of non-throwing code. This approach
 /// encourages explicit error handling and predictable control flow.
 ///
@@ -23,13 +22,10 @@ import Obsidian
 ///
 /// case .failure(.released):
 ///   reconnect_channel()
-///
-/// case .failure(.invalid(let key)):
-///   log_security_event("Invalid key used: \(key)")
 /// }
 /// ```
 ///
-/// The error cases are designed to provide just enough context for proper error
+/// The error case is designed to provide just enough context for proper error
 /// handling without exposing unnecessary implementation details.
 @frozen public enum ChannelError: Error {
   /// Indicates that the channel has been released and can no longer process pulses.
@@ -38,13 +34,4 @@ import Obsidian
   /// explicitly released, or when attempting to release a channel that has
   /// already been released.
   case released
-  
-  /// Indicates that an invalid key was provided when attempting to release a channel.
-  ///
-  /// To prevent unauthorized release of channels, a security key must be provided
-  /// that matches the key used during channel creation. This error includes the
-  /// invalid key that was provided, which can be useful for security auditing.
-  ///
-  /// - Parameter key: The invalid UUID that was provided during the release attempt
-  case invalid(key: UUID)
 }

--- a/Sources/Channel/Types/ChannelResult.swift
+++ b/Sources/Channel/Types/ChannelResult.swift
@@ -25,10 +25,6 @@
 /// case .failure(.released):
 ///   // Channel was already released
 ///   handle_released_channel()
-///
-/// case .failure(.invalid(let key)):
-///   // Invalid key was provided
-///   log_invalid_key_error(key)
 /// }
 /// ```
 ///


### PR DESCRIPTION
**BREAKING CHANGE**

The original implementation of Channel (not oss project) didn't use key based auth for release. I had anxiety around the possibility of a channel getting passed and a sender calling it.

The reality is this has very little real world benefit and is a massive pain to keep around in primitives that build on channel - which is the primary expected usage pattern of Sable.

Channels aren't intended to be passed around or have multiple senders without being very sure of what someone is doing. So at the risk of making some poor design choices easier, I'm relaxing this requirement to make all other code also easier.