### PR TITLE
feat(stream): add stream to sable

### DIFF
--- a/Sources/Stream/Pulses/StreamReleased.swift
+++ b/Sources/Stream/Pulses/StreamReleased.swift
@@ -1,0 +1,38 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Represents a stream lifecycle event indicating that a stream has been released.
+///
+/// `StreamReleased` is a simple event type used internally by the `Stream` system to
+/// notify handlers when a stream endpoint has been released. It contains no payload data,
+/// as the event itself is the message - the stream connection has been terminated.
+///
+/// This type conforms to `Pulsable` to enable it to be sent through channels as part
+/// of the stream lifecycle notification system. The static factory method `pulse()`
+/// provides a convenient way to create fully-formed pulse messages containing this event.
+///
+/// Example usage within the Stream system:
+///
+/// ```swift
+/// // Send a stream released notification
+/// await notification_channel.send(StreamReleased.pulse())
+/// ```
+public struct StreamReleased: Pulsable {
+  /// Creates a new pulse containing a StreamReleased event.
+  ///
+  /// This factory method creates a fully-configured pulse containing a
+  /// StreamReleased event.
+  ///
+  /// ```swift
+  /// // Create and send a stream released notification
+  /// let release_pulse = StreamReleased.pulse()
+  /// await notification_channel.send(release_pulse)
+  /// ```
+  ///
+  /// - Returns: A new pulse containing a StreamReleased event
+  static func pulse() -> Pulse<StreamReleased> {
+    return Pulse(StreamReleased())
+  }
+}

--- a/Sources/Stream/Pulses/StreamReleased.swift
+++ b/Sources/Stream/Pulses/StreamReleased.swift
@@ -19,7 +19,7 @@
 /// // Send a stream released notification
 /// await notification_channel.send(StreamReleased.pulse())
 /// ```
-public struct StreamReleased: Pulsable {
+@frozen public struct StreamReleased: Pulsable {
   /// Creates a new pulse containing a StreamReleased event.
   ///
   /// This factory method creates a fully-configured pulse containing a

--- a/Sources/Stream/Stream.swift
+++ b/Sources/Stream/Stream.swift
@@ -1,0 +1,206 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Obsidian
+
+/// A communication pathway with built-in bidirectional lifecycle awareness. Built on
+/// `Channel` for chain-of-trust primitives.
+///
+/// `Stream` extends Sable's messaging architecture by providing a connection between
+/// components with mutual awareness of lifecycle events. Unlike a regular `Channel`,
+/// which offers unidirectional fire-and-forget messaging, a `Stream` establishes a
+/// relationship where both ends can be notified when either side releases the connection.
+///
+/// This bidirectional lifecycle awareness enables components to properly clean up resources,
+/// disconnect dependencies, or switch to alternative communication paths when a connection
+/// is lost. The `Stream` conforms to `Channeling` to enable seamless integration with
+/// existing channel-based architectures.
+///
+/// Key features:
+/// - Bidirectional lifecycle awareness through notification channels
+/// - Type-safe data passing with Pulse encapsulation
+/// - Actor isolation for thread safety
+/// - Conformance to `Channeling` for interoperability with regular channels
+/// - Clean resource management when streams are released
+///
+/// Streams maintain three internal channels:
+/// - A primary data channel for the main message flow
+/// - Two notification channels for lifecycle events (source release and sink release)
+///
+/// This architecture enables robust connection management in distributed systems where
+/// components need to react appropriately when their communication partners disconnect.
+///
+/// Example usage:
+///
+/// ```swift
+/// // Create a stream with data and lifecycle handlers
+/// let resource_stream = Stream(
+///   data_handler: { pulse in
+///     // Process data flowing through the stream
+///     await resource_service.process(pulse.data)
+///   },
+///   source_released_handler: { _ in
+///     // Handle source closing the stream
+///     await resource_service.disconnect_source()
+///   },
+///   sink_released_handler: { _ in
+///     // Handle sink closing the stream
+///     await resource_service.release_resources()
+///   }
+/// )
+///
+/// // Send data through the stream
+/// let result = await resource_stream.send(data_pulse)
+///
+/// // Release the stream when no longer needed
+/// await resource_stream.release()
+/// ```
+final public actor Stream<Data: Pulsable>: Channeling {
+  
+  // Primary data channel from source to sink
+  private var data_channel: Optional<Channel<Data>>
+  
+  // Source closure notification channel
+  private var source_released_channel: Optional<Channel<StreamReleased>>
+  
+  // Sink closure notification channel
+  private var sink_released_channel: Optional<Channel<StreamReleased>>
+  
+  /// Creates a new stream with the specified handlers.
+  ///
+  /// This initializer establishes the three internal channels that form the stream's
+  /// communication infrastructure:
+  /// - A data channel for the primary message flow
+  /// - Optional notification channels for lifecycle events
+  ///
+  /// The notification channels are only created if handlers are provided, allowing
+  /// for efficient resource usage when full bidirectional awareness isn't needed.
+  /// Each notification channel is dedicated to a specific direction of release
+  /// notification, ensuring clear separation of concerns and predictable behavior.
+  ///
+  /// ```swift
+  /// // Create a stream with both lifecycle handlers
+  /// let full_stream = Stream(
+  ///   data_handler: message_processor.handle,
+  ///   source_released_handler: { _ in handle_source_disconnect() },
+  ///   sink_released_handler: { _ in handle_sink_disconnect() }
+  /// )
+  ///
+  /// // Create a stream with only source release notification
+  /// let source_aware_stream = Stream(
+  ///   data_handler: message_processor.handle,
+  ///   source_released_handler: { _ in handle_source_disconnect() }
+  /// )
+  ///
+  /// // Create a simple stream with no lifecycle awareness
+  /// let simple_stream = Stream(
+  ///   data_handler: message_processor.handle
+  /// )
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - data_handler: Handler that processes data flowing from source to sink
+  ///   - source_released_handler: Optional handler notified when source closes the stream
+  ///   - sink_released_handler: Optional handler notified when sink closes the stream
+  public init(
+    data_handler: @escaping ChannelHandler<Data>,
+    source_released_handler: Optional<ChannelHandler<StreamReleased>> = .none,
+    sink_released_handler: Optional<ChannelHandler<StreamReleased>> = .none
+  ) {
+    // Create the data channel
+    self.data_channel = Channel(handler: data_handler)
+    
+    // Create the source closed notification channel only if a handler is provided
+    self.source_released_channel = source_released_handler.transform { handler in
+      Channel(handler: handler)
+    }
+    
+    // Create the sink closed notification channel only if a handler is provided
+    self.sink_released_channel = sink_released_handler.transform { handler in
+      Channel(handler: handler)
+    }
+  }
+  
+  /// Sends data from the source to the sink.
+  ///
+  /// This method forwards the provided pulse to the stream's internal data channel
+  /// for processing by the registered data handler. It follows the same pattern as
+  /// Channel's send method, but with additional checking for stream release status.
+  ///
+  /// If the stream has been released (data_channel is nil), the method immediately
+  /// returns a failure result without attempting to send the pulse. This behavior
+  /// ensures that attempts to use a released stream produce consistent, predictable
+  /// responses rather than unexpected errors.
+  ///
+  /// ```swift
+  /// // Send a data pulse through the stream
+  /// let result = await stream.send(data_pulse)
+  ///
+  /// // Check if the stream was available
+  /// if case .failure(.released) = result {
+  ///   // Handle the case where the stream was already released
+  ///   recreate_stream_connection()
+  /// }
+  /// ```
+  ///
+  /// - Parameter pulse: The typed pulse to send through this stream
+  /// - Returns: A result indicating success or a specific channel error
+  @discardableResult
+  public func send(_ pulse: Pulse<Data>) async -> ChannelResult {
+    return await data_channel.transform { channel in
+      return await channel.send(pulse)
+    }.otherwise(.failure(.released))
+  }
+  
+  /// Releases the stream, preventing further pulse processing.
+  ///
+  /// This method performs a complete shutdown of the stream by:
+  /// 1. Checking if the stream is already released (data_channel is nil)
+  /// 2. Sending release notifications through both notification channels (if they exist)
+  /// 3. Releasing all three internal channels
+  /// 4. Clearing the channel references to allow proper resource cleanup
+  ///
+  /// The release process follows a careful sequence to ensure that all notifications
+  /// are sent before the data channel is released, providing connected components
+  /// with an opportunity to react to the stream closure.
+  ///
+  /// ```swift
+  /// // Release a stream when it's no longer needed
+  /// let result = await stream.release()
+  ///
+  /// if case .success = result {
+  ///   // Stream was successfully released
+  ///   log_event("Stream shutdown completed")
+  /// } else {
+  ///   // Stream was already released
+  ///   log_warning("Attempted to release an already released stream")
+  /// }
+  /// ```
+  ///
+  /// - Returns: A result indicating success or a specific channel error
+  @discardableResult
+  public func release() async -> ChannelResult {
+    guard let _ = data_channel else { return .failure(.released) }
+    
+    source_released_channel = await source_released_channel.transform { channel in
+      await channel.send(StreamReleased.pulse())
+      await channel.release()
+      return .none
+    }
+    
+    sink_released_channel = await sink_released_channel.transform { channel in
+      await channel.send(StreamReleased.pulse())
+      await channel.release()
+      return .none
+    }
+    
+    data_channel = await data_channel.transform { channel in
+      await channel.release()
+      return .none
+    }
+    
+    return .success
+  }
+}

--- a/Tests/StreamTests/Pulses/StreamReleasedTests.swift
+++ b/Tests/StreamTests/Pulses/StreamReleasedTests.swift
@@ -1,0 +1,42 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import Sable
+
+@Suite("Sable/Stream/Types: StreamReleased")
+struct StreamReleasedTests {
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("conforms to Pulsable")
+  func conforms_to_pulsable() throws {
+    let is_pulsable = (StreamReleased.self as Any) is any Pulsable.Type
+    #expect(is_pulsable)
+  }
+  
+  // MARK: - Factory Method Tests
+  
+  @Test("pulse() creates a Pulse containing StreamReleased")
+  func pulse_creates_pulse_containing_stream_released() throws {
+    // When
+    let pulse = StreamReleased.pulse()
+    
+    // Then
+    #expect(type(of: pulse.data) == StreamReleased.self)
+  }
+  
+  @Test("pulse() creates a unique pulse each time")
+  func pulse_creates_unique_pulse_each_time() throws {
+    // When
+    let pulse1 = StreamReleased.pulse()
+    let pulse2 = StreamReleased.pulse()
+    
+    // Then
+    #expect(pulse1.id != pulse2.id)
+  }
+}

--- a/Tests/StreamTests/StreamTests.swift
+++ b/Tests/StreamTests/StreamTests.swift
@@ -1,0 +1,226 @@
+// Copyright © 2025 Cassidy Spring (Bee). 🖤 Sable Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import Sable
+
+@Suite("Sable/Stream/Core: Stream")
+struct StreamTests {
+  
+  // MARK: - Test Data
+  
+  struct TestData: Pulsable {
+    let message: String
+  }
+  
+  func create_test_pulse() -> Pulse<TestData> {
+    return Pulse(TestData(message: "Test Message"))
+  }
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("conforms to Channeling")
+  func conforms_to_channeling() throws {
+    let is_channeling = (Stream<TestData>.self as Any) is any Channeling.Type
+    #expect(is_channeling)
+  }
+  
+  // MARK: - Initialization Tests
+  
+  @Test("initializes with data handler only")
+  func initializes_with_data_handler_only() throws {
+    let handler: ChannelHandler<TestData> = { _ in }
+    
+    let _ = Stream(data_handler: handler)
+    
+    // No assertion needed - the test passes if initialization doesn't throw
+  }
+  
+  @Test("initializes with all handlers")
+  func initializes_with_all_handlers() throws {
+    let data_handler: ChannelHandler<TestData> = { _ in }
+    let source_released_handler: ChannelHandler<StreamReleased> = { _ in }
+    let sink_released_handler: ChannelHandler<StreamReleased> = { _ in }
+    
+    let _ = Stream(
+      data_handler: data_handler,
+      source_released_handler: source_released_handler,
+      sink_released_handler: sink_released_handler
+    )
+    
+    // No assertion needed - the test passes if initialization doesn't throw
+  }
+  
+  // MARK: - Send Tests
+  
+  @Test("send delivers pulse to data handler")
+  func send_delivers_pulse_to_data_handler() async throws {
+    // Given
+    let pulse = create_test_pulse()
+    let expected_message = pulse.data.message
+    
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let data_handler: ChannelHandler<TestData> = { received_pulse in
+        #expect(received_pulse.data.message == expected_message)
+        confirm()
+      }
+      
+      let stream = Stream(data_handler: data_handler)
+      let result = await stream.send(pulse)
+      try await Task.sleep(for: .milliseconds(100))
+      
+      if case .success = result {
+        // Success case verified
+      } else {
+        #expect(Bool(false), "Expected success result from send")
+      }
+    }
+  }
+  
+  @Test("send returns error when stream is released")
+  func send_returns_error_when_stream_released() async throws {
+    // Given
+    let pulse = create_test_pulse()
+    let data_handler: ChannelHandler<TestData> = { _ in }
+    
+    let stream = Stream(data_handler: data_handler)
+    
+    // When
+    let release_result = await stream.release()
+    if case .failure = release_result {
+      #expect(Bool(false), "Stream release should have succeeded")
+    }
+    
+    // Then
+    let send_result = await stream.send(pulse)
+    
+    if case .failure(let error) = send_result {
+      if case .released = error {
+        // Success - got the released error as expected
+      } else {
+        #expect(Bool(false), "Expected released error but got different error")
+      }
+    } else {
+      #expect(Bool(false), "Expected failure result from send")
+    }
+  }
+  
+  // MARK: - Release Tests
+  
+  @Test("release succeeds")
+  func release_succeeds() async throws {
+    // Given
+    let data_handler: ChannelHandler<TestData> = { _ in }
+    
+    let stream = Stream(data_handler: data_handler)
+    
+    // When
+    let result = await stream.release()
+    
+    // Then
+    if case .success = result {
+      // Success case verified
+    } else {
+      #expect(Bool(false), "Expected success result from release")
+    }
+  }
+  
+  @Test("release fails when already released")
+  func release_fails_when_already_released() async throws {
+    // Given
+    let data_handler: ChannelHandler<TestData> = { _ in }
+    
+    let stream = Stream(data_handler: data_handler)
+    
+    // When
+    let first_result = await stream.release()
+    if case .failure = first_result {
+      #expect(Bool(false), "First stream release should have succeeded")
+    }
+    
+    // Then
+    let second_result = await stream.release()
+    
+    if case .failure(let error) = second_result {
+      if case .released = error {
+        // Success - got the released error as expected
+      } else {
+        #expect(Bool(false), "Expected released error but got different error")
+      }
+    } else {
+      #expect(Bool(false), "Expected failure result from second release")
+    }
+  }
+  
+  // MARK: - Notification Tests
+  
+  @Test("release notifies source released handler")
+  func release_notifies_source_released_handler() async throws {
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let data_handler: ChannelHandler<TestData> = { _ in }
+      
+      let source_released_handler: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let stream = Stream(
+        data_handler: data_handler,
+        source_released_handler: source_released_handler
+      )
+      
+      let _ = await stream.release()
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  @Test("release notifies sink released handler")
+  func release_notifies_sink_released_handler() async throws {
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let data_handler: ChannelHandler<TestData> = { _ in }
+      
+      let sink_released_handler: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let stream = Stream(
+        data_handler: data_handler,
+        sink_released_handler: sink_released_handler
+      )
+      
+      let _ = await stream.release()
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  @Test("release notifies both handlers")
+  func release_notifies_both_handlers() async throws {
+    // When/Then
+    try await confirmation(expectedCount: 2) { (confirm) async throws -> Void in
+      let data_handler: ChannelHandler<TestData> = { _ in }
+      
+      let source_released_handler: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let sink_released_handler: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let stream = Stream(
+        data_handler: data_handler,
+        source_released_handler: source_released_handler,
+        sink_released_handler: sink_released_handler
+      )
+      
+      let _ = await stream.release()
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+}

--- a/Tests/StreamTests/StreamTests.swift
+++ b/Tests/StreamTests/StreamTests.swift
@@ -21,14 +21,6 @@ struct StreamTests {
     return Pulse(TestData(message: "Test Message"))
   }
   
-  // MARK: - Protocol Conformance Tests
-  
-  @Test("conforms to Channeling")
-  func conforms_to_channeling() throws {
-    let is_channeling = (Stream<TestData>.self as Any) is any Channeling.Type
-    #expect(is_channeling)
-  }
-  
   // MARK: - Initialization Tests
   
   @Test("initializes with data handler only")


### PR DESCRIPTION
Streams!!! Streams are built on Channels using chain-of-trust and provide bidirectional lifecycle handling of both sides of the stream. They're a core component for other, incoming, Sable features and are expected to be the primary driver of most systems. Channels are still useful independently when lighter weight solutions are needed, of course. <3