### PR TITLE
feat(stream): add representable to stream

### DIFF
--- a/Sources/Stream/Pulses/StreamReleased.swift
+++ b/Sources/Stream/Pulses/StreamReleased.swift
@@ -3,36 +3,30 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import Obsidian
+
 /// Represents a stream lifecycle event indicating that a stream has been released.
 ///
 /// `StreamReleased` is a simple event type used internally by the `Stream` system to
-/// notify handlers when a stream endpoint has been released. It contains no payload data,
-/// as the event itself is the message - the stream connection has been terminated.
+/// notify handlers when a stream endpoint has been released. It contains the stream's
+/// unique identifier, allowing for proper stream identification in multi-stream systems.
 ///
 /// This type conforms to `Pulsable` to enable it to be sent through channels as part
-/// of the stream lifecycle notification system. The static factory method `pulse()`
-/// provides a convenient way to create fully-formed pulse messages containing this event.
+/// of the stream lifecycle notification system.
+///
+/// The stream identity is provided in two complementary ways:
+/// - Directly via the `stream_id` property for immediate access
+/// - Through pulse metadata as the source, accessible via `pulse.meta.source`
+///
+/// This dual approach provides both self-documentation and framework consistency.
 ///
 /// Example usage within the Stream system:
 ///
 /// ```swift
 /// // Send a stream released notification
-/// await notification_channel.send(StreamReleased.pulse())
+/// await notification_channel.send(Pulse(StreamReleased(stream_id: self.id)).from(self))
 /// ```
 @frozen public struct StreamReleased: Pulsable {
-  /// Creates a new pulse containing a StreamReleased event.
-  ///
-  /// This factory method creates a fully-configured pulse containing a
-  /// StreamReleased event.
-  ///
-  /// ```swift
-  /// // Create and send a stream released notification
-  /// let release_pulse = StreamReleased.pulse()
-  /// await notification_channel.send(release_pulse)
-  /// ```
-  ///
-  /// - Returns: A new pulse containing a StreamReleased event
-  static func pulse() -> Pulse<StreamReleased> {
-    return Pulse(StreamReleased())
-  }
+  /// The unique identifier of the stream that was released
+  public let stream_id: UUID
 }

--- a/Tests/StreamTests/Pulses/StreamReleasedTests.swift
+++ b/Tests/StreamTests/Pulses/StreamReleasedTests.swift
@@ -21,22 +21,16 @@ struct StreamReleasedTests {
   
   // MARK: - Factory Method Tests
   
-  @Test("pulse() creates a Pulse containing StreamReleased")
+  @Test("Pulse creates a Pulse containing StreamReleased")
   func pulse_creates_pulse_containing_stream_released() throws {
+    // Given
+    let id: UUID = UUID()
+
     // When
-    let pulse = StreamReleased.pulse()
+    let pulse = Pulse(StreamReleased(stream_id: id))
     
     // Then
     #expect(type(of: pulse.data) == StreamReleased.self)
-  }
-  
-  @Test("pulse() creates a unique pulse each time")
-  func pulse_creates_unique_pulse_each_time() throws {
-    // When
-    let pulse1 = StreamReleased.pulse()
-    let pulse2 = StreamReleased.pulse()
-    
-    // Then
-    #expect(pulse1.id != pulse2.id)
+    #expect(pulse.data.stream_id == id)
   }
 }


### PR DESCRIPTION
This has two benefits:
1. It forces an ID, which let's either side of the stream track it.
2. We can pass the ID in StreamReleased as both a value and metadata source.