### PR TITLE
deps(dependabot): add swift ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@
 
 version: 2
 updates:
+  - package-ecosystem: swift
+    open-pull-requests-limit: 10
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - beeauvin
   - package-ecosystem: github-actions
     open-pull-requests-limit: 10
     directory: /


### PR DESCRIPTION
Only have one dependency (Obsidian) but hey, this means I wont forget to update one after the other?