### PR TITLE
feat(channel): [breaking] nonisolated channel send

### DIFF
--- a/Sources/Channel/Channel.swift
+++ b/Sources/Channel/Channel.swift
@@ -67,14 +67,16 @@ final public actor Channel<Data: Pulsable>: Channeling {
   /// appropriately.
   ///
   /// ```swift
-  /// await channel.send(login_pulse)
+  /// channel.send(login_pulse)
   /// ```
   ///
   /// The channel guarantees that the pulse will be delivered to the handler,
   /// with the handler executing asynchronously to maintain non-blocking behavior.
   ///
   /// - Parameter pulse: The typed pulse to send to this channel
-  public func send(_ pulse: Pulse<Data>) async {
-    await pipe.send(pulse)
+  public nonisolated func send(_ pulse: Pulse<Data>) {
+    Task.detached(priority: pulse.priority) {
+      await self.pipe.send(pulse)
+    }
   }
 }

--- a/Sources/Channel/Protocols/Channeling.swift
+++ b/Sources/Channel/Protocols/Channeling.swift
@@ -41,5 +41,5 @@ public protocol Channeling<Data> {
   /// Sends a pulse to this channel for processing.
   ///
   /// - Parameter pulse: The typed pulse to send through this channel
-  func send(_ pulse: Pulse<Data>) async
+  func send(_ pulse: Pulse<Data>)
 }

--- a/Tests/ChannelTests/ChannelTests.swift
+++ b/Tests/ChannelTests/ChannelTests.swift
@@ -52,7 +52,7 @@ struct ChannelTests {
       }
       
       let channel = Channel(handler: handler)
-      await channel.send(pulse)
+      channel.send(pulse)
       try await Task.sleep(for: .milliseconds(100))
     }
   }
@@ -75,9 +75,9 @@ struct ChannelTests {
       
       let channel = Channel(handler: handler)
       
-      await channel.send(pulse1)
-      await channel.send(pulse2)
-      await channel.send(pulse3)
+      channel.send(pulse1)
+      channel.send(pulse2)
+      channel.send(pulse3)
       
       try await Task.sleep(for: .milliseconds(100))
     }
@@ -106,10 +106,10 @@ struct ChannelTests {
     #expect(weak_service != nil, "Service should be retained by channel's handler")
     
     // Clean up
-    await channel.send(pulse)
+    channel.send(pulse)
     try await Task.sleep(for: .milliseconds(100))
   }
-  
+
   // MARK: - Task Priority Tests
   
   @Test("send creates task with pulse priority")
@@ -126,7 +126,7 @@ struct ChannelTests {
       }
       
       let channel = Channel(handler: handler)
-      await channel.send(pulse)
+      channel.send(pulse)
       try await Task.sleep(for: .milliseconds(100))
     }
   }
@@ -147,8 +147,8 @@ struct ChannelTests {
       }
       
       let channel = Channel(handler: handler)
-      await channel.send(low_pulse)
-      await channel.send(high_pulse)
+      channel.send(low_pulse)
+      channel.send(high_pulse)
       try await Task.sleep(for: .milliseconds(100))
     }
   }


### PR DESCRIPTION
This changes Channel's `send` method from being async to being sync. Functionally they are basically the same result - send is still a fire and forget operation. But this lets channels be used in synchronous code (like SwiftUI views) with notably less boilerplate.