### PR TITLE
perf(channel): do not use detached tasks

### DIFF
--- a/Sources/Channel/Channel.swift
+++ b/Sources/Channel/Channel.swift
@@ -75,7 +75,7 @@ final public actor Channel<Data: Pulsable>: Channeling {
   ///
   /// - Parameter pulse: The typed pulse to send to this channel
   public nonisolated func send(_ pulse: Pulse<Data>) {
-    Task.detached(priority: pulse.priority) {
+    Task(priority: pulse.priority) {
       await self.pipe.send(pulse)
     }
   }


### PR DESCRIPTION
Overhead isn't needed here and it'd be better to leave this up to the calling context. Ultimately it's just pulse delivery not a long running task so shouldn't really be needed.